### PR TITLE
bugfix: use guzzle for http storage

### DIFF
--- a/Common/HttpClientFactory.php
+++ b/Common/HttpClientFactory.php
@@ -10,15 +10,17 @@ class HttpClientFactory
      * @param string $baseUrl
      * @param array  $headers
      * @param int    $timeout
+     * @param bool   $allowRedirects
      *
      * @return Client
      */
-    public static function create(string $baseUrl, array $headers = [], $timeout = 30): Client
+    public static function create(string $baseUrl, array $headers = [], $timeout = 30, bool $allowRedirects = false): Client
     {
         return new Client([
             'base_uri' => $baseUrl,
             'headers'  => $headers,
-            'timeout'  => $timeout
+            'timeout'  => $timeout,
+            'allow_redirects' => $allowRedirects,
         ]);
     }
 }

--- a/Storage/Processor/Processor.php
+++ b/Storage/Processor/Processor.php
@@ -5,6 +5,7 @@ namespace EMS\CommonBundle\Storage\Processor;
 use EMS\CommonBundle\Helper\ArrayTool;
 use EMS\CommonBundle\Storage\NotFoundException;
 use EMS\CommonBundle\Storage\StorageManager;
+use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\HeaderUtils;
@@ -40,18 +41,31 @@ class Processor
 
         $handler = $this->getResource($config);
 
-        $response =  new StreamedResponse(
-            function () use ($handler) {
+        if ($handler instanceof StreamInterface) {
+            $callback = function () use ($handler) {
+                if ($handler->isSeekable()) {
+                    $handler->rewind();
+                }
+                if (!$handler->isReadable()) {
+                    echo $handler;
+                    return;
+                }
+                while (!$handler->eof()) {
+                    echo $handler->read(8192);
+                }
+            };
+        } else {
+            $callback = function () use ($handler) {
                 while (!feof($handler)) {
                     print fread($handler, 8192);
                 }
-            },
-            200,
-            [
+            };
+        }
+
+        $response =  new StreamedResponse($callback,200, [
             'Content-Disposition' => $config->getDisposition().'; '.HeaderUtils::toString(array('filename' => $filename), ';'),
             'Content-Type' => $config->getMimeType(),
-            ]
-        );
+        ]);
         $response->setPrivate()->setLastModified($config->getLastUpdateDate())->setEtag($cacheKey);
         return $response;
     }

--- a/Storage/Processor/Processor.php
+++ b/Storage/Processor/Processor.php
@@ -212,7 +212,7 @@ class Processor
 
     /**
      * @param Config $config
-     * @return resource
+     * @return resource|StreamInterface
      */
     private function getResource(Config $config)
     {

--- a/Storage/Processor/Processor.php
+++ b/Storage/Processor/Processor.php
@@ -62,7 +62,7 @@ class Processor
             };
         }
 
-        $response =  new StreamedResponse($callback,200, [
+        $response =  new StreamedResponse($callback, 200, [
             'Content-Disposition' => $config->getDisposition().'; '.HeaderUtils::toString(array('filename' => $filename), ';'),
             'Content-Type' => $config->getMimeType(),
         ]);


### PR DESCRIPTION
Because the backend ems is redirect, we need to use guzzle http client.
Implement a streamInterface callback for the streamedResponse.