### PR TITLE
Processor use files

### DIFF
--- a/Helper/EmsFields.php
+++ b/Helper/EmsFields.php
@@ -8,16 +8,23 @@ final class EmsFields
     const CONTENT_FILE_HASH_FIELD = 'sha1';
     const CONTENT_FILE_SIZE_FIELD = 'filesize';
     const CONTENT_FILE_NAME_FIELD = 'filename';
+    const CONTENT_MIME_TYPE_FIELD_ = '_mime_type';
+    const CONTENT_FILE_HASH_FIELD_ = '_hash';
+    const CONTENT_FILE_ALGO_FIELD_ = '_algo';
+    const CONTENT_FILE_SIZE_FIELD_ = '_file_size';
+    const CONTENT_FILE_NAME_FIELD_ = '_filename';
+    const CONTENT_FILE_NAMES = '_file_names';
     const CONTENT_HASH_ALGO_FIELD = '_hash_algo';
     const CONTENT_PUBLISHED_DATETIME_FIELD = '_published_datetime';
 
 
     const ASSET_CONFIG_DISPOSITION = '_disposition';
-    const ASSET_CONFIG_BACKGOUND = '_background';
+    const ASSET_CONFIG_BACKGROUND = '_background';
     const ASSET_CONFIG_TYPE = '_config_type';
     const ASSET_CONFIG_TYPE_IMAGE = 'image';
     const ASSET_CONFIG_GRAVITY = '_gravity';
     const ASSET_CONFIG_MIME_TYPE = '_mime_type';
+    const ASSET_CONFIG_FILE_NAMES = '_file_names';
     const ASSET_CONFIG_HEIGHT = '_height';
     const ASSET_CONFIG_QUALITY = '_quality';
     const ASSET_CONFIG_RESIZE = '_resize';

--- a/Storage/Processor/Config.php
+++ b/Storage/Processor/Config.php
@@ -19,7 +19,7 @@ final class Config
     private $options;
     /** @var string */
     private $configHash;
-    /** @var string */
+    /** @var ?string */
     private $filename;
     /** @var StorageManager */
     private $storageManager;

--- a/Storage/Processor/Processor.php
+++ b/Storage/Processor/Processor.php
@@ -3,7 +3,6 @@
 namespace EMS\CommonBundle\Storage\Processor;
 
 use EMS\CommonBundle\Helper\ArrayTool;
-use EMS\CommonBundle\Storage\NotFoundException;
 use EMS\CommonBundle\Storage\StorageManager;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
@@ -29,8 +28,8 @@ class Processor
 
     public function getResponse(Request $request, string $hash, string $configHash, string $filename)
     {
-        $configJson = $this->storageManager->getContents($configHash);
-        $config = new Config($configHash, $hash, $configHash, json_decode($configJson, true));
+        $configJson = json_decode($this->storageManager->getContents($configHash), true);
+        $config = new Config($this->storageManager, $configHash, $hash, $configHash, $configJson);
         $cacheKey = $config->getCacheKey();
 
         $cacheResponse = new Response();
@@ -62,8 +61,8 @@ class Processor
             };
         }
 
-        $response =  new StreamedResponse($callback, 200, [
-            'Content-Disposition' => $config->getDisposition().'; '.HeaderUtils::toString(array('filename' => $filename), ';'),
+        $response = new StreamedResponse($callback, 200, [
+            'Content-Disposition' => $config->getDisposition() . '; ' . HeaderUtils::toString(array('filename' => $filename), ';'),
             'Content-Type' => $config->getMimeType(),
         ]);
         $response->setPrivate()->setLastModified($config->getLastUpdateDate())->setEtag($cacheKey);
@@ -152,10 +151,10 @@ class Processor
         $jsonOptions = ArrayTool::normalizeAndSerializeArray($options);
         $configHash = $this->storageManager->computeStringHash($jsonOptions);
         try {
-            return new Config($processor, $hash, $configHash, $options);
+            return new Config($this->storageManager, $processor, $hash, $configHash, $options);
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
-            return new Config($processor, $hash, $configHash);
+            return new Config($this->storageManager, $processor, $hash, $configHash);
         }
     }
 
@@ -170,15 +169,13 @@ class Processor
     }
 
 
-    /**
-     * @param Config $config
-     * @return resource
-     */
     private function generateResource(Config $config)
     {
         $file = null;
         if (!$config->cacheableResult()) {
             $file = $this->storageManager->getPublicImage('big-logo.png');
+        } elseif ($config->getFilename()) {
+            $file = $config->getFilename();
         }
         if ($config->getConfigType() === 'image') {
             return fopen($this->generateImage($config, $file), 'r');
@@ -210,28 +207,22 @@ class Processor
     }
 
 
-    /**
-     * @param Config $config
-     * @return resource|StreamInterface
-     */
-    private function getResource(Config $config)
+    private function getResource(Config $config, string $filename)
     {
         $cacheableResult = $config->cacheableResult();
-        if (!$config->getStorageContext() || $cacheableResult) {
-            try {
-                return $this->storageManager->getResource($config->getAssetHash(), $config->getStorageContext());
-            } catch (NotFoundException $e) {
-                if (!$config->getStorageContext()) {
-                    throw $e;
-                }
+        if (!$config->getStorageContext()) {
+            if ($config->getFilename()) {
+                return fopen($config->getFilename(), 'r');
             }
+
+            return $this->storageManager->getResource($config->getAssetHash(), $config->getStorageContext());
         }
 
 
 
         $generatedResource = $this->generateResource($config);
         if ($cacheableResult) {
-            $this->storageManager->cacheResource($generatedResource, $config->getAssetHash(), $config->getConfigHash(), 'file'.$config->getFilenameExtension(), $config->getMimeType());
+            $this->storageManager->cacheResource($generatedResource, $config->getAssetHash(), $config->getConfigHash(), $filename, $config->getMimeType());
         }
 
         return $generatedResource;

--- a/Storage/Processor/Processor.php
+++ b/Storage/Processor/Processor.php
@@ -38,7 +38,7 @@ class Processor
             return $cacheResponse;
         }
 
-        $handler = $this->getResource($config);
+        $handler = $this->getResource($config, $filename);
 
         if ($handler instanceof StreamInterface) {
             $callback = function () use ($handler) {

--- a/Storage/StorageManager.php
+++ b/Storage/StorageManager.php
@@ -189,7 +189,7 @@ class StorageManager
         return $this->hashAlgo;
     }
 
-    public function saveContents(string $contents, string $filename, string $mimetype, string $context = null, int $shouldBeSavedOnXServices = 0)
+    public function saveContents(string $contents, string $filename, string $mimetype, string $context = null, int $shouldBeSavedOnXServices = 1)
     {
         $hash = hash($this->hashAlgo, $contents);
         $out = 0;


### PR DESCRIPTION
I added a new asset config parameters _file_names. This parameters can contains an array of files. If one of this file exists it will be used to be processed by the asset processor. So there is no need to specify a hash if you have at least on file referred in this parameter.

Bellow an example with Aperture. I have beside my elasticms an Aperture database. Aperture generated a lot of previews directly in it's DB. As I dont want to duplicates all those images and I do not want to loose time to register them in ems I can process them directly from my twigs:

`{# the list of potential files from my external source#}
{% set fileNames = {} %}
{% if source.imageProxy.fullSizePreviewPath %}
    {% set fileNames = fileNames|merge(['/Users/theus/Pictures/Aperture\ Library.aplibrary/Previews/'~source.imageProxy.fullSizePreviewPath]) %}
{% endif %}
{% if source.imageProxy.thumbnailPath %}
    {% set fileNames = fileNames|merge(['/Users/theus/Pictures/Aperture\ Library.aplibrary/Thumbnails/'~source.imageProxy.thumbnailPath]) %}
{% endif %}
{% if source.imageProxy.miniThumbnailPath %}
    {% set fileNames = fileNames|merge(['/Users/theus/Pictures/Aperture\ Library.aplibrary/Thumbnails/'~source.imageProxy.miniThumbnailPath]) %}
{% endif %}

<a href={{ ems_asset_path( { 
        _filename: source.fileName
    },{
        _file_names: fileNames
    }) }}>
    <img src="{{ ems_asset_path( { 
            _filename: source.fileName
        },{
            _config_type: 'image',
            _width: 200,
            _height: 200,
            _file_names: fileNames
        }) }}">
</a>`