### PR TITLE
Support transparancy for the _background image processor's attribute

### DIFF
--- a/Controller/FileController.php
+++ b/Controller/FileController.php
@@ -111,9 +111,12 @@ class FileController extends AbstractController
      */
     private function closeSession(Request $request)
     {
-        $session = $request->getSession();
+        if (!$request->hasSession()) {
+            return;
+        }
 
-        if ($session && $session->isStarted()) {
+        $session = $request->getSession();
+        if ($session->isStarted()) {
             $session->save();
         }
     }

--- a/Helper/EmsFields.php
+++ b/Helper/EmsFields.php
@@ -64,6 +64,8 @@ final class EmsFields
     const LOG_LEVEL_NAME_FIELD = 'level_name';
     const LOG_CHANNEL_FIELD = 'channel';
     const LOG_DATETIME_FIELD = 'datetime';
+    const LOG_FIELD_IN_ERROR_FIELD = 'field';
+    const LOG_PATH_IN_ERROR_FIELD = 'path';
 
     const LOG_OPERATION_CREATE = 'CREATE';
     const LOG_OPERATION_UPDATE = 'UPDATE';

--- a/Helper/Text/Encoder.php
+++ b/Helper/Text/Encoder.php
@@ -30,6 +30,20 @@ class Encoder
 
     /**
      *
+     * Detect url information using the '"http//host:proto/url/target"' pattern
+     * <a href="http//host:proto/url/target">target</a>
+     */
+    public function encodeUrl(string $text): string
+    {
+        $urlRegex = '/(?P<proto>([\w\d-\.]+:)?)\/\/(?P<host>[\w\d-\.]+(:[0-9]+)?)\/(?P<baseurl>([\w\d-\._]+\/)*)(?P<target>[\w\d-\._]+)/';
+
+        return preg_replace_callback($urlRegex, function ($matches) {
+            return sprintf('<a href="%s//%s/%s%s">%s</a>', $matches['proto'], $matches['host'], $matches['baseurl'], $matches['target'], $matches['target']);
+        }, $text);
+    }
+
+    /**
+     *
      * Detect email information using the 'x@x.x' pattern
      * <a href="mailto:david.meert@smals.be">david.meert@smals.be</a>
      */

--- a/Logger/ElasticsearchLogger.php
+++ b/Logger/ElasticsearchLogger.php
@@ -290,7 +290,8 @@ class ElasticsearchLogger extends AbstractProcessingHandler implements CacheWarm
             return;
         }
 
-        switch ($event->getRequest()->getMethod()) {
+        $request = $event->getRequest();
+        switch ($request->getMethod()) {
             case 'POST':
             case 'PUT':
                 $operation = EmsFields::LOG_OPERATION_CREATE;
@@ -307,7 +308,7 @@ class ElasticsearchLogger extends AbstractProcessingHandler implements CacheWarm
             default:
                 $operation = null;
         }
-        $route = $event->getRequest()->attributes->get('_route', null);
+        $route = $request->attributes->get('_route', null);
         if ($operation && $route && !in_array($route, ['_wdt'])) {
             $statusCode = $event->getResponse()->getStatusCode();
             if ($statusCode < 300) {
@@ -332,17 +333,16 @@ class ElasticsearchLogger extends AbstractProcessingHandler implements CacheWarm
                 'message' => 'app.request',
                 'context' => [
                     EmsFields::LOG_OPERATION_FIELD => $operation,
-                    EmsFields::LOG_HOST_FIELD => $event->getRequest()->getHost(),
-                    EmsFields::LOG_URL_FIELD => $event->getRequest()->getRequestUri(),
+                    EmsFields::LOG_HOST_FIELD => $request->getHost(),
+                    EmsFields::LOG_URL_FIELD => $request->getRequestUri(),
                     EmsFields::LOG_ROUTE_FIELD => $route,
                     EmsFields::LOG_STATUS_CODE_FIELD => $statusCode,
                     EmsFields::LOG_SIZE_FIELD => strlen($event->getResponse()->getContent()),
                     EmsFields::LOG_MICROTIME_FIELD => (microtime(true) - $this->startMicrotime),
                 ],
             ];
-            $session = $event->getRequest()->getSession();
-            if ($session !== null && $session->getId() !== null) {
-                $record['context'][EmsFields::LOG_SESSION_ID_FIELD] = $session->getId();
+            if ($request->hasSession()) {
+                $record['context'][EmsFields::LOG_SESSION_ID_FIELD] = $request->getSession()->getId();
             }
             $this->write($record);
         }

--- a/Storage/Processor/Config.php
+++ b/Storage/Processor/Config.php
@@ -168,9 +168,9 @@ final class Config
         return $this->options[EmsFields::ASSET_CONFIG_GRAVITY];
     }
 
-    public function getRadius(): ?string
+    public function getRadius(): int
     {
-        return $this->options[EmsFields::ASSET_CONFIG_RADIUS];
+        return \intval($this->options[EmsFields::ASSET_CONFIG_RADIUS]);
     }
 
     public function getRadiusGeometry(): array

--- a/Storage/Processor/Config.php
+++ b/Storage/Processor/Config.php
@@ -133,9 +133,9 @@ final class Config
         return $this->options[EmsFields::ASSET_CONFIG_TYPE];
     }
 
-    public function getQuality(): ?int
+    public function getQuality(): int
     {
-        return $this->options[EmsFields::ASSET_CONFIG_QUALITY];
+        return $this->options[EmsFields::ASSET_CONFIG_QUALITY] ?? 0;
     }
 
     public function getFileNames(): ?array

--- a/Storage/Processor/Config.php
+++ b/Storage/Processor/Config.php
@@ -261,8 +261,8 @@ final class Config
         return [
             EmsFields::ASSET_CONFIG_TYPE => null,
             EmsFields::ASSET_CONFIG_FILE_NAMES => null,
-            EmsFields::ASSET_CONFIG_QUALITY => 70,
-            EmsFields::ASSET_CONFIG_BACKGROUND => '#FFFFFF',
+            EmsFields::ASSET_CONFIG_QUALITY => 0,
+            EmsFields::ASSET_CONFIG_BACKGROUND => '#FFFFFFFF',
             EmsFields::ASSET_CONFIG_RESIZE => 'fill',
             EmsFields::ASSET_CONFIG_WIDTH => 300,
             EmsFields::ASSET_CONFIG_HEIGHT => 200,

--- a/Storage/Processor/Image.php
+++ b/Storage/Processor/Image.php
@@ -47,7 +47,7 @@ class Image
         }
 
         $path = tempnam(sys_get_temp_dir(), 'ems_image');
-        if (($this->config->getQuality() ?? 0)  > 0) {
+        if ($this->config->getQuality()  > 0) {
             imagejpeg($image, $path, $this->config->getQuality());
         } else {
             imagepng($image, $path);

--- a/Storage/Processor/Image.php
+++ b/Storage/Processor/Image.php
@@ -38,7 +38,7 @@ class Image
             $image = $this->applyBackground($image, $width, $height);
         }
 
-        if (null !== $this->config->getRadius()) {
+        if (($this->config->getRadius() ?? 0) > 0) {
             $image = $this->applyCorner($image, $width, $height);
         }
 
@@ -47,7 +47,7 @@ class Image
         }
 
         $path = tempnam(sys_get_temp_dir(), 'ems_image');
-        if ($this->config->getQuality()) {
+        if (($this->config->getQuality() ?? 0)  > 0) {
             imagejpeg($image, $path, $this->config->getQuality());
         } else {
             imagepng($image, $path);
@@ -97,6 +97,21 @@ class Image
         return [$width, $height];
     }
 
+    private function fillBackgroundColor($temp)
+    {
+        $background = $this->config->getBackground();
+        imagesavealpha($temp, true);
+
+        $solid_colour = imagecolorallocatealpha(
+            $temp,
+            \hexdec(\substr($background, 1, 2)),
+            \hexdec(\substr($background, 3, 2)),
+            \hexdec(\substr($background, 5, 2)),
+            \intval(\hexdec(\substr($background, 7, 2) ?? '00') / 2)
+        );
+        imagefill($temp, 0, 0, $solid_colour);
+    }
+
     private function applyResizeAndBackground($image, $width, $height, $size)
     {
         if (function_exists("imagecreatetruecolor") && ($temp = imagecreatetruecolor($width, $height))) {
@@ -106,14 +121,7 @@ class Image
             $resizeFunction = 'imagecopyresized';
         }
 
-        $background = $this->config->getBackground();
-        $solid_colour = imagecolorallocate(
-            $temp,
-            hexdec(substr($background, 1, 2)),
-            hexdec(substr($background, 3, 2)),
-            hexdec(substr($background, 5, 2))
-        );
-        imagefill($temp, 0, 0, $solid_colour);
+        $this->fillBackgroundColor($temp);
 
         $resize = $this->config->getResize();
         $gravity = $this->config->getGravity();
@@ -162,15 +170,7 @@ class Image
             $resizeFunction = 'imagecopyresized';
         }
 
-        $background = $this->config->getBackground();
-        $solid_colour = imagecolorallocate(
-            $temp,
-            hexdec(substr($background, 1, 2)),
-            hexdec(substr($background, 3, 2)),
-            hexdec(substr($background, 5, 2))
-        );
-        imagefill($temp, 0, 0, $solid_colour);
-
+        $this->fillBackgroundColor($temp);
 
         call_user_func($resizeFunction, $temp, $image, 0, 0, 0, 0, $width, $height, $width, $height);
 

--- a/Storage/Processor/Image.php
+++ b/Storage/Processor/Image.php
@@ -38,7 +38,7 @@ class Image
             $image = $this->applyBackground($image, $width, $height);
         }
 
-        if (($this->config->getRadius() ?? 0) > 0) {
+        if ($this->config->getRadius() > 0) {
             $image = $this->applyCorner($image, $width, $height);
         }
 
@@ -102,14 +102,14 @@ class Image
         $background = $this->config->getBackground();
         imagesavealpha($temp, true);
 
-        $solid_colour = imagecolorallocatealpha(
+        $solidColour = imagecolorallocatealpha(
             $temp,
             \hexdec(\substr($background, 1, 2)),
             \hexdec(\substr($background, 3, 2)),
             \hexdec(\substr($background, 5, 2)),
             \intval(\hexdec(\substr($background, 7, 2) ?? '00') / 2)
         );
-        imagefill($temp, 0, 0, $solid_colour);
+        imagefill($temp, 0, 0, $solidColour);
     }
 
     private function applyResizeAndBackground($image, $width, $height, $size)
@@ -179,7 +179,7 @@ class Image
 
     private function applyCorner($image, $width, $height)
     {
-        $radius = (int) $this->config->getRadius();
+        $radius = $this->config->getRadius();
         $color = $this->config->getBorderColor() ?? $this->config->getBackground();
 
         $cornerImage = imagecreatetruecolor($radius, $radius);

--- a/Storage/Processor/Processor.php
+++ b/Storage/Processor/Processor.php
@@ -239,7 +239,7 @@ class Processor
         }
 
         try {
-            $this->storageManager->cacheResource($generatedResource, $config->getAssetHash(), $config->getConfigHash(), $filename, $config->getMimeType());
+            $this->storageManager->cacheResource($generatedResource, $config->getAssetHash(), $config->getConfigHash(), $filename, $config->getMimeType(), 1);
         } catch (\Exception $e) {
             $this->logger->warning('log.unexpected_exception', ['error_message' => $e->getMessage()]);
         }

--- a/composer.json
+++ b/composer.json
@@ -22,27 +22,27 @@
 		"ext-json": "*",
 		"ext-mbstring": "*",
 		"aws/aws-sdk-php": "^3.109",
+		"doctrine/doctrine-bundle": "^1.11",
+		"doctrine/orm": "^2.6",
 		"elasticsearch/elasticsearch" : "~5.3.0",
 		"guzzlehttp/guzzle" : "^6.3",
-		"twig/twig" : "^2.10",
-		"symfony/routing": "^4.3",
-		"symfony/http-foundation": "^4.3",
-		"symfony/monolog-bundle": "^3.4",
-		"symfony/security": "^4.3",
-		"symfony/translation": "^4.3",
-		"doctrine/orm": "^2.6",
-		"symfony/framework-bundle": "^4.3",
-		"symfony/stopwatch": "^4.3",
-		"symfony/options-resolver": "^4.3",
-		"doctrine/doctrine-bundle": "^1.11"
+		"symfony/framework-bundle": "^4.4",
+		"symfony/http-foundation": "^4.4",
+		"symfony/monolog-bridge": "^4.4",
+		"symfony/options-resolver": "^4.4",
+		"symfony/routing": "^4.4",
+		"symfony/security": "^4.4",
+		"symfony/stopwatch": "^4.4",
+		"symfony/translation": "^4.4",
+		"twig/twig" : "^2.10"
 	},
 	"require-dev" : {
-		"phpunit/phpunit" : "^5.7",
 		"mockery/mockery" : "^0.9",
-		"symfony/phpunit-bridge": "^4.3",
-		"squizlabs/php_codesniffer": "^3.4",
 		"phpstan/phpstan": "^0.11",
-		"symfony/web-profiler-bundle": "^4.3"
+		"phpunit/phpunit" : "^5.7",
+		"squizlabs/php_codesniffer": "^3.4",
+		"symfony/phpunit-bridge": "^4.4",
+		"symfony/web-profiler-bundle": "^4.4"
 	},
 	"autoload" : {
 		"psr-4" : {

--- a/tests/Unit/Helper/Text/EncoderTest.php
+++ b/tests/Unit/Helper/Text/EncoderTest.php
@@ -67,4 +67,34 @@ class EncoderTest extends TestCase
     {
         self::assertSame($expected, $this->encoder->htmlEncodePii($text));
     }
+
+    /**
+     * format: [text, text;]
+     */
+    public function urlProvider(): array
+    {
+
+        return [
+            ['example', 'example'],
+            ['See //host:80/demo/test.html', 'See <a href="//host:80/demo/test.html">test.html</a>'],
+            ['//host/base/test', '<a href="//host/base/test">test</a>'],
+            ['//host/base/more/complex/test', '<a href="//host/base/more/complex/test">test</a>'],
+            ['//host/test', '<a href="//host/test">test</a>'],
+            ['Before //host/base/test after', 'Before <a href="//host/base/test">test</a> after'],
+            ['See http://host:80/demo/test.html', 'See <a href="http://host:80/demo/test.html">test.html</a>'],
+            ['https://host/base/test', '<a href="https://host/base/test">test</a>'],
+            ['ftp://host/base/more/complex/test', '<a href="ftp://host/base/more/complex/test">test</a>'],
+            ['errr://host/test', '<a href="errr://host/test">test</a>'],
+            ['errr//host/test', 'errr<a href="//host/test">test</a>'],
+        ];
+    }
+
+
+    /**
+     * @dataProvider urlProvider
+     */
+    public function testHtmlEncodeUrl(string $text, string $expected)
+    {
+        self::assertSame($expected, $this->encoder->encodeUrl($text));
+    }
 }


### PR DESCRIPTION
if the _background asset config attribute is set to #FF0000 or #FF000000, the background will be red without transparency. With #FF0000FF it will be fully transparent. It works only if the _quality is set to 0 and than if a PNG is generated