### PR TITLE
Limit the save of generated assets to 1 storage service

### DIFF
--- a/Storage/Processor/Processor.php
+++ b/Storage/Processor/Processor.php
@@ -239,7 +239,7 @@ class Processor
         }
 
         try {
-            $this->storageManager->cacheResource($generatedResource, $config->getAssetHash(), $config->getConfigHash(), $filename, $config->getMimeType());
+            $this->storageManager->cacheResource($generatedResource, $config->getAssetHash(), $config->getConfigHash(), $filename, $config->getMimeType(), 1);
         } catch (\Exception $e) {
             $this->logger->warning('log.unexpected_exception', ['error_message' => $e->getMessage()]);
         }


### PR DESCRIPTION
Quick debug to avoid to save generated assets (like cropped images) are saved on too many (or too slow) storage services.