### PR TITLE
bug[twig]: dash in ulr pattern are not escaped in regex

### DIFF
--- a/Helper/Text/Encoder.php
+++ b/Helper/Text/Encoder.php
@@ -41,7 +41,7 @@ class Encoder
      */
     public function encodeUrl(string $text): string
     {
-        $urlRegex = '/(?P<proto>([\w\d-\.]+:)?)\/\/(?P<host>[\w\d-\.]+(:[0-9]+)?)\/(?P<baseurl>([\w\d-\._]+\/)*)(?P<target>[\w\d-\._]+)/';
+        $urlRegex = '/(?P<proto>([\w\d\-\.]+:)?)\/\/(?P<host>[\w\d\-\.]+(:[0-9]+)?)\/(?P<baseurl>([\w\d\-\._]+\/)*)(?P<target>[\w\d\-\._]+)/';
 
         $encodedText = preg_replace_callback($urlRegex, function ($matches) {
             return sprintf('<a href="%s//%s/%s%s">%s</a>', $matches['proto'], $matches['host'], $matches['baseurl'], $matches['target'], $matches['target']);


### PR DESCRIPTION

|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |Y|	
|Fixed tickets  |N|	

Prepare the migration to PHP 7.4