### PR TITLE
fix: S3 doesn't supports \rename

### DIFF
--- a/Storage/Service/S3Storage.php
+++ b/Storage/Service/S3Storage.php
@@ -57,12 +57,15 @@ class S3Storage extends AbstractUrlStorage
 
     public function finalizeUpload(string $hash): bool
     {
-        $out = parent::finalizeUpload($hash);
-        $path = $this->getUploadPath($hash);
+        $source = $this->getUploadPath($hash);
+        $destination  = $this->getPath($hash);
+        \copy($source, $destination);
+
         $this->s3Client->deleteObject([
             'Bucket'     => $this->bucket,
-            'Key'        => substr($path, 1 + strlen($this->getBaseUrl()))
+            'Key'        => substr($source, 1 + strlen($this->getBaseUrl()))
         ]);
-        return $out;
+
+        return true;
     }
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

some s3 systems, such NetApp StorageGRID, might return false on \rename call in parent::finalizeUpload as S3 doesn't support rename