### PR TITLE
Feat/response from config object

### DIFF
--- a/Storage/Processor/Config.php
+++ b/Storage/Processor/Config.php
@@ -15,8 +15,6 @@ use function GuzzleHttp\Psr7\mimetype_from_filename;
 final class Config
 {
     /** @var string */
-    private $processor;
-    /** @var string */
     private $assetHash;
     /** @var array<string, mixed> */
     private $options;
@@ -34,10 +32,9 @@ final class Config
     /**
      * @param array<string, mixed>  $options
      */
-    public function __construct(StorageManager $storageManager, string $processor, string $assetHash, string $configHash, array $options = [])
+    public function __construct(StorageManager $storageManager, string $assetHash, string $configHash, array $options = [])
     {
         $this->storageManager = $storageManager;
-        $this->processor = $processor;
         $this->assetHash = $assetHash;
         $this->options = $this->resolve($options);
         $this->configHash = $configHash;
@@ -86,11 +83,6 @@ final class Config
     public function hasDefaultMimeType(): bool
     {
         return \in_array($this->options[EmsFields::ASSET_CONFIG_MIME_TYPE] ?? '', ['application/octet-stream', 'application/bin', '']);
-    }
-
-    public function getProcessor(): string
-    {
-        return $this->processor;
     }
 
     public function getAssetHash(): string

--- a/Twig/RequestRuntime.php
+++ b/Twig/RequestRuntime.php
@@ -135,7 +135,7 @@ class RequestRuntime implements RuntimeExtensionInterface
         $hashConfig = $this->storageManager->saveContents($normalizedArray, 'assetConfig.json', 'application/json', 1);
 
         if (isset($config[EmsFields::ASSET_CONFIG_GET_FILE_PATH]) && $config[EmsFields::ASSET_CONFIG_GET_FILE_PATH]) {
-            $configObj = new Config($this->storageManager, $hashConfig, $hash, $hashConfig, $config);
+            $configObj = new Config($this->storageManager, $hash, $hashConfig, $config);
 
             $filesystem = new Filesystem();
             if ($hash) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |Y|	
|BC breaks?     |N|	
|Deprecations?  |Y|	
|Fixed tickets  |N|	

We can also get an asset response directly from a Config object without serialize/save the config in a json file. As we need a route to download asset from the admin/core regardless any config (binary download).