### PR TITLE
feat: elastica service health status

### DIFF
--- a/src/Service/ElasticaService.php
+++ b/src/Service/ElasticaService.php
@@ -28,6 +28,18 @@ class ElasticaService
         $this->logger = $logger;
     }
 
+    public function getHealthStatus(): string
+    {
+        try {
+            $clusterHealthResponse = $this->client->request('_cluster/health');
+
+            return $clusterHealthResponse->getData()['status'] ?? 'red';
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage(), ['trace' => $e->getTraceAsString()]);
+            return 'red';
+        }
+    }
+
     public function search(Search $search): ResultSet
     {
         return $this->createElasticaSearch($search, $search->getSearchOptions())->search();


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Add getHealthStatus method in elasticaService.

IMPORTANT:

Running the following code was causing a big memory usage on a big
cluster.

$client->getCluster()->getHealth()->getStatus();