### PR TITLE
fix: default usage attribute value must be a string (not a int)

### DIFF
--- a/src/Storage/Factory/AbstractFactory.php
+++ b/src/Storage/Factory/AbstractFactory.php
@@ -16,7 +16,7 @@ abstract class AbstractFactory implements StorageFactoryInterface
         $resolver
             ->setDefaults([
                 self::STORAGE_CONFIG_TYPE => null,
-                self::STORAGE_CONFIG_USAGE => StorageInterface::STORAGE_USAGE_CACHE,
+                self::STORAGE_CONFIG_USAGE => StorageInterface::STORAGE_USAGE_CACHE_ATTRIBUTE,
             ])
             ->setAllowedTypes(self::STORAGE_CONFIG_TYPE, 'string')
             ->setAllowedTypes(self::STORAGE_CONFIG_USAGE, 'string')

--- a/src/Storage/Factory/EntityFactory.php
+++ b/src/Storage/Factory/EntityFactory.php
@@ -66,7 +66,7 @@ class EntityFactory extends AbstractFactory implements StorageFactoryInterface
             ->setDefaults([
                 self::STORAGE_CONFIG_TYPE => self::STORAGE_TYPE,
                 self::STORAGE_CONFIG_ACTIVATE => true,
-                self::STORAGE_CONFIG_USAGE => StorageInterface::STORAGE_USAGE_CONFIG,
+                self::STORAGE_CONFIG_USAGE => StorageInterface::STORAGE_USAGE_CONFIG_ATTRIBUTE,
             ])
             ->setAllowedTypes(self::STORAGE_CONFIG_ACTIVATE, 'bool')
             ->setAllowedValues(self::STORAGE_CONFIG_TYPE, [self::STORAGE_TYPE])

--- a/src/Storage/Factory/HttpFactory.php
+++ b/src/Storage/Factory/HttpFactory.php
@@ -67,7 +67,7 @@ class HttpFactory extends AbstractFactory implements StorageFactoryInterface
                 self::STORAGE_CONFIG_BASE_URL => null,
                 self::STORAGE_CONFIG_GET_URL => '/public/file/',
                 self::STORAGE_CONFIG_AUTH_KEY => null,
-                self::STORAGE_CONFIG_USAGE => StorageInterface::STORAGE_USAGE_BACKUP,
+                self::STORAGE_CONFIG_USAGE => StorageInterface::STORAGE_USAGE_BACKUP_ATTRIBUTE,
             ])
             ->setRequired(self::STORAGE_CONFIG_GET_URL)
             ->setAllowedTypes(self::STORAGE_CONFIG_BASE_URL, ['null', 'string'])

--- a/src/Storage/Factory/SftpFactory.php
+++ b/src/Storage/Factory/SftpFactory.php
@@ -79,7 +79,7 @@ class SftpFactory extends AbstractFactory implements StorageFactoryInterface
                 self::STORAGE_CONFIG_PRIVATE_KEY_FILE => null,
                 self::STORAGE_CONFIG_PASSWORD_PHRASE => null,
                 self::STORAGE_CONFIG_PORT => 22,
-                self::STORAGE_CONFIG_USAGE => StorageInterface::STORAGE_USAGE_BACKUP,
+                self::STORAGE_CONFIG_USAGE => StorageInterface::STORAGE_USAGE_BACKUP_ATTRIBUTE,
             ])
             ->setRequired([
                 self::STORAGE_CONFIG_TYPE,

--- a/src/Storage/Service/StorageInterface.php
+++ b/src/Storage/Service/StorageInterface.php
@@ -18,14 +18,24 @@ interface StorageInterface
     public const STORAGE_USAGE_BACKUP = 3;
     /** @var int  */
     public const STORAGE_USAGE_EXTERNAL = 4;
+    /** @var string  */
+    public const STORAGE_USAGE_CACHE_ATTRIBUTE = 'cache';
+    /** @var string  */
+    public const STORAGE_USAGE_CONFIG_ATTRIBUTE = 'config';
+    /** @var string  */
+    public const STORAGE_USAGE_ASSET_ATTRIBUTE = 'asset';
+    /** @var string  */
+    public const STORAGE_USAGE_BACKUP_ATTRIBUTE = 'backup';
+    /** @var string  */
+    public const STORAGE_USAGE_EXTERNAL_ATTRIBUTE = 'external';
 
     /** @var array<string, int> */
     public const STORAGE_USAGES = [
-        'usage' => self::STORAGE_USAGE_CACHE,
-        'config' => self::STORAGE_USAGE_CONFIG,
-        'asset' => self::STORAGE_USAGE_ASSET,
-        'backup' => self::STORAGE_USAGE_BACKUP,
-        'external' => self::STORAGE_USAGE_EXTERNAL,
+        self::STORAGE_USAGE_CACHE_ATTRIBUTE => self::STORAGE_USAGE_CACHE,
+        self::STORAGE_USAGE_CONFIG_ATTRIBUTE => self::STORAGE_USAGE_CONFIG,
+        self::STORAGE_USAGE_ASSET_ATTRIBUTE => self::STORAGE_USAGE_ASSET,
+        self::STORAGE_USAGE_BACKUP_ATTRIBUTE => self::STORAGE_USAGE_BACKUP,
+        self::STORAGE_USAGE_EXTERNAL_ATTRIBUTE => self::STORAGE_USAGE_EXTERNAL,
     ];
 
     public function head(string $hash): bool;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	
