### PR TITLE
feat: addTermsAggregation, generateTermsSearch and getBoolQuery functions

### DIFF
--- a/src/Search/Search.php
+++ b/src/Search/Search.php
@@ -3,6 +3,7 @@
 namespace EMS\CommonBundle\Search;
 
 use Elastica\Aggregation\AbstractAggregation;
+use Elastica\Aggregation\Terms;
 use Elastica\Query\AbstractQuery;
 use Elastica\Search as ElasticaSearch;
 use EMS\CommonBundle\Elasticsearch\Document\EMSSource;
@@ -144,5 +145,13 @@ class Search
     public function getAggregations(): array
     {
         return $this->aggregations;
+    }
+
+    public function addTermsAggregation(string $name, string $field, int $size = 20): void
+    {
+        $termsAggregation = new Terms($name);
+        $termsAggregation->setField($field);
+        $termsAggregation->setSize($size);
+        $this->addAggregation($termsAggregation);
     }
 }

--- a/src/Service/ElasticaService.php
+++ b/src/Service/ElasticaService.php
@@ -64,6 +64,21 @@ class ElasticaService
         return Document::fromResult($result);
     }
 
+    /**
+     * @param string[] $indexes
+     * @param string[] $terms
+     */
+    public function generateTermsSearch(array $indexes, string $field, array $terms): Search
+    {
+        $query = new Terms($field, $terms);
+        return new Search($indexes, $query);
+    }
+
+    public function getBoolQuery(): BoolQuery
+    {
+        return new BoolQuery();
+    }
+
     public function search(Search $search): ResultSet
     {
         return $this->createElasticaSearch($search, $search->getSearchOptions())->search();


### PR DESCRIPTION
Add an addTermsAggregation in the Search object, add generateTermsSearch and getBoolQuery functions to the elastica service in order to avoid direct dependencies to elastica in emsch and emsco bundles
|Q              |A  |
|---------------|---|
|Bug fix?       |N|
|New feature?   |Y|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	
