### PR TITLE
fix: access array offset bug es response

### DIFF
--- a/src/Elasticsearch/Response/Response.php
+++ b/src/Elasticsearch/Response/Response.php
@@ -27,11 +27,11 @@ final class Response implements ResponseInterface
     /**
      * @param array<mixed> $response
      */
-    private function __construct($response)
+    private function __construct(array $response)
     {
         $this->total = $response['hits']['total']['value'] ?? $response['hits']['total'] ?? 0;
         $this->accurate = true;
-        if ('eq' !== $response['hits']['total']['relation'] ?? null) {
+        if (\is_array($response['hits']['total'] ?? null) && 'eq' !== $response['hits']['total']['relation'] ?? null) {
             $this->accurate = false;
         }
         $this->hits = $response['hits']['hits'] ?? [];


### PR DESCRIPTION
Notice: Trying to access array offset on value of type int
in \vendor/elasticms/common-bundle/src/Elasticsearch/Response/Response.php (line34)

|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	
