### PR TITLE
Fix/array arguments

### DIFF
--- a/src/Logger/ElasticsearchLogger.php
+++ b/src/Logger/ElasticsearchLogger.php
@@ -263,7 +263,15 @@ class ElasticsearchLogger extends AbstractProcessingHandler implements CacheWarm
             return;
         }
 
-        $command = \implode(' ', $event->getInput()->getArguments());
+        $arguments = [];
+        foreach ($event->getInput()->getArguments() as $argument) {
+            if (\is_array($argument)) {
+                $arguments[] = \implode(' ', $argument);
+            } else {
+                $arguments[] = \strval($argument);
+            }
+        }
+        $command = \implode(' ', $arguments);
 
         foreach ($event->getInput()->getOptions() as $id => $value) {
             if ($commandObject->getDefinition()->getOption($id)->getDefault() !== $value) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

If the command as an InputArgument::IS_ARRAY argument the logger will fails : not possible to cast an array to a string