### PR TITLE
bugfix: elasticms cluster access via elastica

### DIFF
--- a/src/Elasticsearch/ElasticaFactory.php
+++ b/src/Elasticsearch/ElasticaFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CommonBundle\Elasticsearch;
 
 use Elasticsearch\ConnectionPool\SniffingConnectionPool;
+use League\Uri\Uri;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
@@ -28,7 +29,12 @@ class ElasticaFactory
     {
         $servers = [];
         foreach ($hosts ?? [] as $host) {
-            $servers[] = \parse_url($host);
+            $url = \parse_url($host);
+            if (isset($url['path'])) {
+                $url['url'] = $host;
+            }
+
+            $servers[] = $url;
         }
 
         $config = [


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

The current implementation using Elastica is not working with elasticsearch hosts that are accessed through our elasticms backend proxies. (elasticms with custom path to define the access to the cluster).

Adding the 'url' in the servers configuration solves the issue, as this prevents Elastica to reconstruct the url. (Elastica is adding a / before the server path (which is already prefixed by the path)).

However, we can't add this url by default, as that would break direct access to elasticsearch clusters!

Possible issues with this fix (which don't apply to us): if an elasticsearch cluster is accessed directly using a path, the implementation might not work! --> Instead of this approach we could go for an extra option "EMS_ACCESS_THROUGH_BACKEND" ?