### PR TITLE
fix: use the url parameter when the scheme is not in http

### DIFF
--- a/src/Elasticsearch/ElasticaFactory.php
+++ b/src/Elasticsearch/ElasticaFactory.php
@@ -28,7 +28,12 @@ class ElasticaFactory
     {
         $servers = [];
         foreach ($hosts ?? [] as $host) {
-            $servers[] = \parse_url($host);
+            $url = \parse_url($host);
+            if (false !== $url && 'http' === ($url['scheme'] ?? null)) {
+                $servers[] = $url;
+            } else {
+                $servers[] = ['url' => $host];
+            }
         }
 
         $config = [

--- a/src/Elasticsearch/ElasticaFactory.php
+++ b/src/Elasticsearch/ElasticaFactory.php
@@ -28,12 +28,10 @@ class ElasticaFactory
     {
         $servers = [];
         foreach ($hosts ?? [] as $host) {
-            $url = \parse_url($host);
-            if (false !== $url && 'http' === ($url['scheme'] ?? null)) {
-                $servers[] = $url;
-            } else {
-                $servers[] = ['url' => $host];
+            if ('/' !== \substr($host, -1)) {
+                $host .= '/';
             }
+            $servers[] = ['url' => $host];
         }
 
         $config = [


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |Y|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

Elastica hardcod the scheme in http in it's client. Hopefully there is an `url` option which can be used to defined the curl base url.  But using that url always expect a trailing url.