### PR TITLE
fix: Perf issue on getIndicesForContentTypes 

### DIFF
--- a/src/Service/ElasticaService.php
+++ b/src/Service/ElasticaService.php
@@ -539,6 +539,7 @@ class ElasticaService
 
         $esQuery = new Query();
         $esQuery->addAggregation($aggContentType);
+        $esQuery->setSize(0);
 
         $esSearch = new ElasticaSearch($this->client);
         $esSearch->setQuery($esQuery);


### PR DESCRIPTION
By default the first 10 documents are fetch. If they are huge this query significantly slow down the request.

|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

