### PR TITLE
fix: the \ceil function will convert 12.8 to 12.0 where the image res…

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -226,16 +226,6 @@ parameters:
 			path: src/Storage/Processor/Image.php
 
 		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Storage\\\\Processor\\\\Image\\:\\:getWidthHeight\\(\\) has parameter \\$size with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Storage/Processor/Image.php
-
-		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Storage\\\\Processor\\\\Image\\:\\:getWidthHeight\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Storage/Processor/Image.php
-
-		-
 			message: "#^Method EMS\\\\CommonBundle\\\\Storage\\\\Processor\\\\Image\\:\\:fillBackgroundColor\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/Storage/Processor/Image.php

--- a/src/Storage/Processor/Image.php
+++ b/src/Storage/Processor/Image.php
@@ -84,6 +84,10 @@ class Image
         return $path;
     }
 
+    /**
+     * @param array<int> $size
+     * @return array<int>
+     */
     private function getWidthHeight(array $size): array
     {
         list($originalWidth, $originalHeight) = $size;
@@ -95,14 +99,14 @@ class Image
             $width = ('*' == $width ? $originalWidth : $width);
             $height = ('*' == $height ? $originalHeight : $height);
 
-            return [$width, $height];
+            return [\intval($width), \intval($height)];
         }
 
         $ratio = $originalWidth / $originalHeight;
 
         if ('*' == $width && '*' == $height) {
             //unable to calculate ratio, silently return original size (backward compatibility)
-            return [$originalWidth, $originalHeight];
+            return [\intval($originalWidth), \intval($originalHeight)];
         }
 
         if ('*' == $width || '*' == $height) {
@@ -121,7 +125,7 @@ class Image
             }
         }
 
-        return [$width, $height];
+        return [\intval($width), \intval($height)];
     }
 
     private function fillBackgroundColor($temp)

--- a/src/Storage/Processor/Image.php
+++ b/src/Storage/Processor/Image.php
@@ -86,6 +86,7 @@ class Image
 
     /**
      * @param array<int> $size
+     *
      * @return array<int>
      */
     private function getWidthHeight(array $size): array


### PR DESCRIPTION
…ize functions (i.e. imagecopyresized) expects integers

|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

- [ ] The image processor throws a non-integer exception in some specific cases