### PR TITLE
Feat/stream zip

### DIFF
--- a/src/Storage/FileCollection.php
+++ b/src/Storage/FileCollection.php
@@ -28,7 +28,7 @@ final class FileCollection implements \IteratorAggregate
     public function getIterator()
     {
         foreach ($this->files as $file) {
-            $file['content'] = $this->storageManager->getContents($file['sha1']);
+            $file['stream'] = $this->storageManager->getStream($file['sha1']);
             yield $file;
         }
     }

--- a/src/Storage/Processor/Processor.php
+++ b/src/Storage/Processor/Processor.php
@@ -85,7 +85,7 @@ class Processor
         return new Config($this->storageManager, $hash, $configHash, $configArray);
     }
 
-    private function generateSteam(Config $config, string $cacheFilename): StreamInterface
+    private function generateStream(Config $config, string $cacheFilename): StreamInterface
     {
         $file = null;
         if (!$config->isCacheableResult()) {
@@ -200,7 +200,7 @@ class Processor
             }
         }
 
-        return $this->generateSteam($config, $cacheFilename);
+        return $this->generateStream($config, $cacheFilename);
     }
 
     private function getResponseFromStreamInterface(StreamInterface $stream, Request $request): StreamedResponse

--- a/src/Storage/Processor/Processor.php
+++ b/src/Storage/Processor/Processor.php
@@ -85,10 +85,7 @@ class Processor
         return new Config($this->storageManager, $hash, $configHash, $configArray);
     }
 
-    /**
-     * @return resource
-     */
-    private function generateResource(Config $config, string $cacheFilename)
+    private function generateSteam(Config $config, string $cacheFilename): StreamInterface
     {
         $file = null;
         if (!$config->isCacheableResult()) {
@@ -102,7 +99,7 @@ class Processor
                 throw new \Exception('It was not able to open the generated image');
             }
 
-            return $resource;
+            return new Stream($resource);
         }
 
         if ('zip' === $config->getConfigType()) {
@@ -111,7 +108,7 @@ class Processor
                 throw new \Exception('It was not able to open the generated zip');
             }
 
-            return $resource;
+            return new Stream($resource);
         }
 
         throw new \Exception(\sprintf('not able to generate file for the config %s', $config->getConfigHash()));
@@ -203,9 +200,7 @@ class Processor
             }
         }
 
-        $generatedResource = $this->generateResource($config, $cacheFilename);
-
-        return new Stream($generatedResource);
+        return $this->generateSteam($config, $cacheFilename);
     }
 
     private function getResponseFromStreamInterface(StreamInterface $stream, Request $request): StreamedResponse

--- a/src/Storage/Processor/Processor.php
+++ b/src/Storage/Processor/Processor.php
@@ -103,12 +103,7 @@ class Processor
         }
 
         if ('zip' === $config->getConfigType()) {
-            $resource = \fopen($this->generateZip($config), 'r');
-            if (false === $resource) {
-                throw new \Exception('It was not able to open the generated zip');
-            }
-
-            return new Stream($resource);
+            return $this->generateZip($config);
         }
 
         throw new \Exception(\sprintf('not able to generate file for the config %s', $config->getConfigHash()));
@@ -145,7 +140,7 @@ class Processor
         return $generatedImage;
     }
 
-    private function generateZip(Config $config): string
+    private function generateZip(Config $config): StreamInterface
     {
         $zip = new Zip($config);
 

--- a/src/Storage/Processor/Zip.php
+++ b/src/Storage/Processor/Zip.php
@@ -32,7 +32,7 @@ class Zip
         $option->setOutputStream($stream);
         $zip = new ZipStream(null, $option);
         foreach ($this->config->getFiles() as $file) {
-            $zip->addFile($file['filename'], $file['content']);
+            $zip->addFileFromPsr7Stream($file['filename'], $file['stream']);
         }
 
         $zip->finish();


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |N|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	


Refactor in order to only use streams when processing a zip (should avoid time-out by reducing the TTFB and avoid temporary, and potentially large, files)