### PR TITLE
feat: add a post_filter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpunit.xml
 
 # Backup entities generated with doctrine:generate:entities command
 **/Entity/*~
+/composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ phpunit.xml
 
 # Backup entities generated with doctrine:generate:entities command
 **/Entity/*~
-/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require" : {
-		"php" : "^7.2.0",
+		"php" : "^7.4",
 		"ext-dom": "*",
 		"ext-gd": "*",
 		"ext-iconv": "*",

--- a/src/Service/ElasticaService.php
+++ b/src/Service/ElasticaService.php
@@ -309,7 +309,6 @@ class ElasticaService
      */
     public function convertElasticsearchSearch(array $param): Search
     {
-        @\trigger_error('This function exists to simplified the migration to elastica, but should not be used on long term', E_USER_DEPRECATED);
         $options = $this->resolveElasticsearchSearchParameters($param);
         $search = $this->convertElasticsearchBody($options['index'], $options['type'], $options['body']);
         $this->setSearchDefaultOptions($search, $options);

--- a/src/Service/ElasticaService.php
+++ b/src/Service/ElasticaService.php
@@ -290,9 +290,11 @@ class ElasticaService
         } elseif (!empty($query)) {
             if (null !== $queryObject) {
                 $boolQuery->addMust($queryObject);
+                $queryObject = $boolQuery;
+                $queryObject->addMust($query);
+            } else {
+                $queryObject = new Simple($query);
             }
-            $queryObject = $boolQuery;
-            $queryObject->addMust($query);
         }
         $search = new Search($indexes, $queryObject);
         $this->setSearchDefaultOptions($search, $options);

--- a/src/Service/ElasticaService.php
+++ b/src/Service/ElasticaService.php
@@ -287,14 +287,12 @@ class ElasticaService
         $query = $options['query'];
         if (!empty($query) && $queryObject instanceof $boolQuery) {
             $queryObject->addMust($query);
+        } elseif (!empty($query) && null !== $queryObject) {
+            $boolQuery->addMust($queryObject);
+            $boolQuery->addMust($query);
+            $queryObject = $boolQuery;
         } elseif (!empty($query)) {
-            if (null !== $queryObject) {
-                $boolQuery->addMust($queryObject);
-                $queryObject = $boolQuery;
-                $queryObject->addMust($query);
-            } else {
-                $queryObject = new Simple($query);
-            }
+            $queryObject = new Simple($query);
         }
         $search = new Search($indexes, $queryObject);
         $this->setSearchDefaultOptions($search, $options);


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |N|
|New feature?   |Y|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

Add the post_filter support in the convertElasticsearchBody function. 
I also discover the Simple query object which can simply convert an array into an Elastica query object. So I took the opportunity to refactor the convertElasticsearchBody function in order to avoir bool query with a single must sub-query