### PR TITLE
fix: it's useless to test the _type for ELK6 and after

### DIFF
--- a/src/Service/ElasticaService.php
+++ b/src/Service/ElasticaService.php
@@ -219,9 +219,21 @@ class ElasticaService
         if (null !== $query) {
             $boolQuery->addMust($query);
         }
+
+        $contentType = new Terms(EMSSource::FIELD_CONTENT_TYPE, $contentTypes);
+
+        $version = $this->getVersion();
+        if (\version_compare($version, '6.0') >= 0) {
+            if ($query instanceof BoolQuery) {
+                $boolQuery = $query;
+            }
+            $boolQuery->addMust($contentType);
+
+            return $boolQuery;
+        }
+
         $boolQuery->setMinimumShouldMatch(1);
         $type = new Terms('_type', $contentTypes);
-        $contentType = new Terms(EMSSource::FIELD_CONTENT_TYPE, $contentTypes);
         $boolQuery->addShould($type);
         $boolQuery->addShould($contentType);
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

Query on the field _type triggers a warning message on elasticsearch 7 and testing _type for elk is useless as we need to rely on the filed _contenttype. 