### PR TITLE
fix: image 0.12.88

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
       - name: PHPStan
-        uses: docker://oskarstark/phpstan-ga
+        uses: docker://oskarstark/phpstan-ga:0.12.88
         env:
           CHECK_PLATFORM_REQUIREMENTS: false
           REQUIRE_DEV: true


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Keep the previous phpstan image to stay in php 7