### PR TITLE
chore: remove dep getRaw on document

### DIFF
--- a/src/Elasticsearch/Document/Document.php
+++ b/src/Elasticsearch/Document/Document.php
@@ -89,14 +89,10 @@ class Document implements DocumentInterface
     }
 
     /**
-     * @deprecated
-     *
      * @return array<string, mixed>
      */
     public function getRaw(): array
     {
-        @\trigger_error('Document::getRaw is deprecated use the others getters', E_USER_DEPRECATED);
-
         return $this->raw;
     }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Sadly the getRaw is currently used by the clientHelperBundle.
In the feature we should deprecate this function but for now it's too strict.