### PR TITLE
chore: remove dep getRaw aggregation

### DIFF
--- a/src/Elasticsearch/Aggregation/Aggregation.php
+++ b/src/Elasticsearch/Aggregation/Aggregation.php
@@ -44,14 +44,10 @@ class Aggregation
     }
 
     /**
-     * @deprecated
-     *
      * @return array<mixed>
      */
     public function getRaw(): array
     {
-        @\trigger_error('Aggregation::getRaw is deprecated use the others getters', E_USER_DEPRECATED);
-
         return $this->raw;
     }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

The clientHelper search is using this for searching. Too soon for a deprecation.