### PR TITLE
refactor: twig runtimes to asset

### DIFF
--- a/doc/processors.md
+++ b/doc/processors.md
@@ -5,7 +5,7 @@
 All file field (indexed file field and file field) share the same base structure:
 
  - filename: mainly the original file name uploaded by the used (but it can be adjusted by the user)
- - mimetype: mainly the original mimetype identified by the user's computer (but it can be adjusted by the user
+ - mimetype: mainly the original mimetype identified by the user's computer (but it can be adjusted by the user). If missing it will be guessed from the filename.
  - sha1: the file's hash
  - filesize: the file size
  
@@ -38,7 +38,9 @@ Regarding the file's type, it's possible to generate response from a source file
  - `_file_names` (array of file path) if provided the first file found will be used instead of the original asset 
  - `_config_type` specify the processor that should process the asset. If not define the asset itself will be delivered
     - `image` will generate an image (PNG, SVG or JPEG) using the [image processor](#Image processor)
+    - `zip` will generate a ZIP archive the [ZIP processor](#ZIP processor)
  - `_get_file_path` if set to true will generate a server path to a file. Not an url path. To use in case of PDF generation or for local reports.
+ - `_mime_type` Can be used to override the file field's `mimetype` value.
  
 In the following example the path generated will force to download the asset:
 ```twig

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -356,11 +356,6 @@ parameters:
 			path: src/Twig/RequestRuntime.php
 
 		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\RequestRuntime\\:\\:endsWith\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Twig/RequestRuntime.php
-
-		-
 			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\RequestRuntime\\:\\:localeAttribute\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Twig/RequestRuntime.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -361,37 +361,7 @@ parameters:
 			path: src/Twig/RequestRuntime.php
 
 		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\RequestRuntime\\:\\:endsWith\\(\\) has parameter \\$haystack with no typehint specified\\.$#"
-			count: 1
-			path: src/Twig/RequestRuntime.php
-
-		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\RequestRuntime\\:\\:endsWith\\(\\) has parameter \\$needle with no typehint specified\\.$#"
-			count: 1
-			path: src/Twig/RequestRuntime.php
-
-		-
 			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\RequestRuntime\\:\\:localeAttribute\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Twig/RequestRuntime.php
-
-		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\TextRuntime\\:\\:htmlEncode\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Twig/TextRuntime.php
-
-		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\TextRuntime\\:\\:htmlEncodePii\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Twig/TextRuntime.php
-
-		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\TextRuntime\\:\\:jsonDecode\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Twig/TextRuntime.php
-
-		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\TextRuntime\\:\\:jsonMenuDecode\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Twig/TextRuntime.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -346,16 +346,6 @@ parameters:
 			path: src/Twig/CommonExtension.php
 
 		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\RequestRuntime\\:\\:assetPath\\(\\) has parameter \\$assetConfig with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Twig/RequestRuntime.php
-
-		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\RequestRuntime\\:\\:assetPath\\(\\) has parameter \\$fileField with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Twig/RequestRuntime.php
-
-		-
 			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\RequestRuntime\\:\\:localeAttribute\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Twig/RequestRuntime.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -335,18 +335,3 @@ parameters:
 			count: 1
 			path: src/Storage/Processor/StreamRange.php
 
-		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\CommonExtension\\:\\:arrayKey\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Twig/CommonExtension.php
-
-		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\CommonExtension\\:\\:arrayKey\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Twig/CommonExtension.php
-
-		-
-			message: "#^Method EMS\\\\CommonBundle\\\\Twig\\\\RequestRuntime\\:\\:localeAttribute\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Twig/RequestRuntime.php
-

--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -13,7 +13,9 @@
         <service id="EMS\CommonBundle\Twig\AssetRuntime">
             <argument type="service" id="ems_common.storage.manager" />
             <argument type="service" id="logger" />
-            <argument type="string">%kernel.project_dir%</argument>
+            <argument type="service" id="Symfony\Component\Routing\Generator\UrlGeneratorInterface" />
+            <argument type="service" id="EMS\CommonBundle\Storage\Processor\Processor" />
+            <argument type="string">%kernel.cache_dir%</argument>
             <tag name="twig.runtime" />
         </service>
         <service id="ems_common.twig.runtime.request" alias="EMS\CommonBundle\Twig\RequestRuntime"/>
@@ -22,10 +24,7 @@
         </service>
         <service id="EMS\CommonBundle\Twig\RequestRuntime">
             <argument type="service" id="request_stack" />
-            <argument type="service" id="ems_common.storage.manager" />
-            <argument type="service" id="Symfony\Component\Routing\Generator\UrlGeneratorInterface" />
-            <argument type="service" id="EMS\CommonBundle\Storage\Processor\Processor" />
-            <argument type="string">%kernel.cache_dir%</argument>
+            <argument type="service" id="EMS\CommonBundle\Twig\AssetRuntime" />
             <tag name="twig.runtime" />
         </service>
 

--- a/src/Storage/Processor/Processor.php
+++ b/src/Storage/Processor/Processor.php
@@ -6,6 +6,7 @@ namespace EMS\CommonBundle\Storage\Processor;
 
 use EMS\CommonBundle\Helper\ArrayTool;
 use EMS\CommonBundle\Helper\Cache;
+use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Storage\NotFoundException;
 use EMS\CommonBundle\Storage\StorageManager;
 use GuzzleHttp\Psr7\Stream;
@@ -249,5 +250,27 @@ class Processor
         }
 
         return $response;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function overwriteMimeType(string $mimeType, array $config): string
+    {
+        switch ($config[EmsFields::ASSET_CONFIG_TYPE] ?? 'none') {
+            case EmsFields::ASSET_CONFIG_TYPE_IMAGE:
+                if ($mimeType && \preg_match('/image\/svg.*/', $mimeType)) {
+                    return $mimeType;
+                }
+                if (0 === ($config[EmsFields::ASSET_CONFIG_QUALITY] ?? 0)) {
+                    return 'image/png';
+                }
+
+                return 'image/jpeg';
+            case EmsFields::ASSET_CONFIG_TYPE_ZIP:
+                return 'application/zip';
+        }
+
+        return $mimeType;
     }
 }

--- a/src/Twig/AssetRuntime.php
+++ b/src/Twig/AssetRuntime.php
@@ -4,28 +4,37 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Twig;
 
+use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CommonBundle\Storage\NotSavedException;
+use EMS\CommonBundle\Storage\Processor\Config;
 use EMS\CommonBundle\Storage\Processor\Processor;
 use EMS\CommonBundle\Storage\StorageManager;
+use GuzzleHttp\Psr7\MimeType;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use ZipArchive;
 
 class AssetRuntime
 {
     private StorageManager $storageManager;
     private LoggerInterface $logger;
-    private string $publicDir;
     private Filesystem $filesystem;
+    private UrlGeneratorInterface $urlGenerator;
+    private Processor $processor;
+    private string $cacheDir;
 
-    public function __construct(StorageManager $storageManager, LoggerInterface $logger, string $projectDir)
+    public function __construct(StorageManager $storageManager, LoggerInterface $logger, UrlGeneratorInterface $urlGenerator, Processor $processor, string $cacheDir)
     {
         $this->storageManager = $storageManager;
         $this->logger = $logger;
-        $this->publicDir = $projectDir.'/public';
         $this->filesystem = new Filesystem();
+        $this->urlGenerator = $urlGenerator;
+        $this->processor = $processor;
+        $this->cacheDir = $cacheDir;
     }
 
     /**
@@ -107,5 +116,179 @@ class AssetRuntime
         $zip->close();
 
         return true;
+    }
+
+    /**
+     * @param array<string, mixed> $fileField
+     * @param array<string, mixed> $assetConfig
+     */
+    public function assetPath(array $fileField, array $assetConfig = [], string $route = 'ems_asset', string $fileHashField = EmsFields::CONTENT_FILE_HASH_FIELD, string $filenameField = EmsFields::CONTENT_FILE_NAME_FIELD, string $mimeTypeField = EmsFields::CONTENT_MIME_TYPE_FIELD, int $referenceType = UrlGeneratorInterface::RELATIVE_PATH): string
+    {
+        $config = $assetConfig;
+
+        $hash = $fileField[EmsFields::CONTENT_FILE_HASH_FIELD_] ?? $fileField[$fileHashField] ?? 'processor';
+        $filename = $fileField[EmsFields::CONTENT_FILE_NAME_FIELD_] ?? $fileField[$filenameField] ?? 'asset.bin';
+        $mimeType = $fileField[EmsFields::CONTENT_MIME_TYPE_FIELD_] ?? $fileField[$mimeTypeField] ?? MimeType::fromFilename($filename) ?? 'application/octet-stream';
+
+        $mimeType = $this->processor->overwriteMimeType($mimeType, $config);
+        $filename = $this->fixFileExtension($filename, $mimeType);
+        $config[EmsFields::ASSET_CONFIG_MIME_TYPE] = $mimeType;
+
+        try {
+            $hashConfig = $this->storageManager->saveConfig($config);
+        } catch (NotSavedException $e) {
+            $hashConfig = $e->getHash();
+        }
+
+        if (!($config[EmsFields::ASSET_CONFIG_GET_FILE_PATH] ?? false)) {
+            return $this->urlGenerator->generate($route, [
+                'hash_config' => $hashConfig,
+                'filename' => \basename($filename),
+                'hash' => $hash ?? $hashConfig,
+            ], $referenceType);
+        }
+
+        $configObj = new Config($this->storageManager, $hash, $hashConfig, $config);
+        $filesystem = new Filesystem();
+        $filesystem->mkdir($this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig);
+        $cacheFilename = $this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig.DIRECTORY_SEPARATOR.$hash;
+
+        if (!$filesystem->exists($cacheFilename)) {
+            $stream = $this->processor->getStream($configObj, $filename);
+            \file_put_contents($cacheFilename, $stream->getContents());
+        }
+
+        return $cacheFilename;
+    }
+
+    public function assetAverageColor(string $hash): string
+    {
+        try {
+            $config = $this->processor->configFactory($hash, [
+                EmsFields::ASSET_CONFIG_TYPE => EmsFields::ASSET_CONFIG_TYPE_IMAGE,
+                EmsFields::ASSET_CONFIG_RESIZE => 'free',
+                EmsFields::ASSET_CONFIG_WIDTH => 1,
+                EmsFields::ASSET_CONFIG_HEIGHT => 1,
+                EmsFields::ASSET_CONFIG_QUALITY => 80,
+                EmsFields::ASSET_CONFIG_MIME_TYPE => 'image/jpeg',
+            ]);
+            $stream = $this->processor->getStream($config, 'one-pixel.jpg');
+
+            $image = \imagecreatefromstring($stream->getContents());
+            if (false === $image) {
+                throw new \RuntimeException('Unexpected imagecreatefromstring error');
+            }
+            $index = \imagecolorat($image, 0, 0);
+            if (false === $index) {
+                throw new \RuntimeException('Unexpected imagecolorat error');
+            }
+            $rgb = \imagecolorsforindex($image, $index);
+            if (false === $rgb) {
+                throw new \RuntimeException('Unexpected imagecolorsforindex error');
+            }
+            $red = \round(\round((($rgb['red'] ?? 255) / 0x33)) * 0x33);
+            $green = \round(\round((($rgb['green'] ?? 255) / 0x33)) * 0x33);
+            $blue = \round(\round((($rgb['blue'] ?? 255) / 0x33)) * 0x33);
+
+            return \sprintf('#%02X%02X%02X', $red, $green, $blue);
+        } catch (\Throwable $e) {
+            return '#FFFFFF';
+        }
+    }
+
+    private function fixFileExtension(string $filename, string $mimeType): string
+    {
+        static $mimetypes = [
+            'video/3gpp' => '3gp',
+            'application/x-7z-compressed' => '7z',
+            'audio/x-aac' => 'aac',
+            'audio/x-aiff' => 'aif',
+            'video/x-ms-asf' => 'asf',
+            'application/atom+xml' => 'atom',
+            'video/x-msvideo' => 'avi',
+            'image/bmp' => 'bmp',
+            'application/x-bzip2' => 'bz2',
+            'application/pkix-cert' => 'cer',
+            'application/pkix-crl' => 'crl',
+            'application/x-x509-ca-cert' => 'crt',
+            'text/css' => 'css',
+            'text/csv' => 'csv',
+            'application/cu-seeme' => 'cu',
+            'application/x-debian-package' => 'deb',
+            'application/msword' => 'doc',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
+            'application/x-dvi' => 'dvi',
+            'application/vnd.ms-fontobject' => 'eot',
+            'application/epub+zip' => 'epub',
+            'text/x-setext' => 'etx',
+            'audio/flac' => 'flac',
+            'video/x-flv' => 'flv',
+            'image/gif' => 'gif',
+            'application/gzip' => 'gz',
+            'text/html' => 'html',
+            'image/x-icon' => 'ico',
+            'text/calendar' => 'ics',
+            'application/x-iso9660-image' => 'iso',
+            'application/java-archive' => 'jar',
+            'image/jpeg' => 'jpeg',
+            'text/javascript' => 'js',
+            'application/json' => 'json',
+            'application/x-latex' => 'latex',
+            'audio/midi' => 'midi',
+            'video/quicktime' => 'mov',
+            'video/x-matroska' => 'mkv',
+            'audio/mpeg' => 'mp3',
+            'video/mp4' => 'mp4',
+            'audio/mp4' => 'mp4a',
+            'video/mpeg' => 'mpeg',
+            'audio/ogg' => 'ogg',
+            'video/ogg' => 'ogv',
+            'application/ogg' => 'ogx',
+            'image/x-portable-bitmap' => 'pbm',
+            'application/pdf' => 'pdf',
+            'image/x-portable-graymap' => 'pgm',
+            'image/png' => 'png',
+            'image/x-portable-anymap' => 'pnm',
+            'image/x-portable-pixmap' => 'ppm',
+            'application/vnd.ms-powerpoint' => 'ppt',
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'pptx',
+            'application/x-rar-compressed' => 'rar',
+            'image/x-cmu-raster' => 'ras',
+            'application/rss+xml' => 'rss',
+            'application/rtf' => 'rtf',
+            'text/sgml' => 'sgml',
+            'image/svg+xml' => 'svg',
+            'application/x-shockwave-flash' => 'swf',
+            'application/x-tar' => 'tar',
+            'image/tiff' => 'tiff',
+            'application/x-bittorrent' => 'torrent',
+            'application/x-font-ttf' => 'ttf',
+            'text/plain' => 'txt',
+            'audio/x-wav' => 'wav',
+            'video/webm' => 'webm',
+            'image/webp' => 'webp',
+            'audio/x-ms-wma' => 'wma',
+            'video/x-ms-wmv' => 'wmv',
+            'application/x-font-woff' => 'woff',
+            'application/wsdl+xml' => 'wsdl',
+            'image/x-xbitmap' => 'xbm',
+            'application/vnd.ms-excel' => 'xls',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx',
+            'application/xml' => 'xml',
+            'image/x-xpixmap' => 'xpm',
+            'image/x-xwindowdump' => 'xwd',
+            'text/yaml' => 'yml',
+            'application/zip' => 'zip',
+        ];
+
+        if (!isset($mimetypes[$mimeType])) {
+            return $filename;
+        }
+
+        if (MimeType::fromFilename($filename) === $mimeType) {
+            return $filename;
+        }
+
+        return \implode('.', [\pathinfo($filename, PATHINFO_FILENAME), $mimetypes[$mimeType]]);
     }
 }

--- a/src/Twig/AssetRuntime.php
+++ b/src/Twig/AssetRuntime.php
@@ -128,7 +128,7 @@ class AssetRuntime
 
         $hash = $fileField[EmsFields::CONTENT_FILE_HASH_FIELD_] ?? $fileField[$fileHashField] ?? 'processor';
         $filename = $fileField[EmsFields::CONTENT_FILE_NAME_FIELD_] ?? $fileField[$filenameField] ?? 'asset.bin';
-        $mimeType = $fileField[EmsFields::CONTENT_MIME_TYPE_FIELD_] ?? $fileField[$mimeTypeField] ?? MimeType::fromFilename($filename) ?? 'application/octet-stream';
+        $mimeType = $config[EmsFields::ASSET_CONFIG_MIME_TYPE] ?? $fileField[EmsFields::CONTENT_MIME_TYPE_FIELD_] ?? $fileField[$mimeTypeField] ?? MimeType::fromFilename($filename) ?? 'application/octet-stream';
 
         $mimeType = $this->processor->overwriteMimeType($mimeType, $config);
         $filename = $this->fixFileExtension($filename, $mimeType);

--- a/src/Twig/AssetRuntime.php
+++ b/src/Twig/AssetRuntime.php
@@ -15,14 +15,10 @@ use ZipArchive;
 
 class AssetRuntime
 {
-    /** @var StorageManager */
-    private $storageManager;
-    /** @var LoggerInterface */
-    private $logger;
-    /** @var string */
-    private $publicDir;
-    /** @var Filesystem */
-    private $filesystem;
+    private StorageManager $storageManager;
+    private LoggerInterface $logger;
+    private string $publicDir;
+    private Filesystem $filesystem;
 
     public function __construct(StorageManager $storageManager, LoggerInterface $logger, string $projectDir)
     {

--- a/src/Twig/CommonExtension.php
+++ b/src/Twig/CommonExtension.php
@@ -46,6 +46,11 @@ class CommonExtension extends AbstractExtension
         return \file_exists($filename);
     }
 
+    /**
+     * @param array<mixed> $array
+     *
+     * @return array<mixed>
+     */
     public function arrayKey(array $array, string $key = 'key'): array
     {
         $out = [];

--- a/src/Twig/CommonExtension.php
+++ b/src/Twig/CommonExtension.php
@@ -14,7 +14,7 @@ class CommonExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('ems_asset_path', [RequestRuntime::class, 'assetPath'], ['is_safe' => ['html']]),
+            new TwigFunction('ems_asset_path', [AssetRuntime::class, 'assetPath'], ['is_safe' => ['html']]),
             new TwigFunction('ems_unzip', [AssetRuntime::class, 'unzip']),
         ];
     }
@@ -37,7 +37,7 @@ class CommonExtension extends AbstractExtension
             new TwigFilter('ems_markdown', [Encoder::class, 'markdownToHtml'], ['is_safe' => ['html']]),
             new TwigFilter('ems_stringify', [Converter::class, 'stringify']),
             new TwigFilter('ems_temp_file', [AssetRuntime::class, 'temporaryFile']),
-            new TwigFilter('ems_asset_average_color', [RequestRuntime::class, 'assetAverageColor'], ['is_safe' => ['html']]),
+            new TwigFilter('ems_asset_average_color', [AssetRuntime::class, 'assetAverageColor'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/CommonExtension.php
+++ b/src/Twig/CommonExtension.php
@@ -11,9 +11,6 @@ use Twig\TwigFunction;
 
 class CommonExtension extends AbstractExtension
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getFunctions()
     {
         return [
@@ -22,9 +19,6 @@ class CommonExtension extends AbstractExtension
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFilters()
     {
         return [
@@ -52,10 +46,7 @@ class CommonExtension extends AbstractExtension
         return \file_exists($filename);
     }
 
-    /**
-     * @param string $key
-     */
-    public function arrayKey(array $array, $key = 'key'): array
+    public function arrayKey(array $array, string $key = 'key'): array
     {
         $out = [];
 

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -15,20 +15,11 @@ use Twig\Extension\RuntimeExtensionInterface;
 
 class RequestRuntime implements RuntimeExtensionInterface
 {
-    /** @var RequestStack */
-    private $requestStack;
-
-    /** @var StorageManager */
-    private $storageManager;
-
-    /** @var UrlGeneratorInterface */
-    private $urlGenerator;
-
-    /** @var Processor */
-    private $processor;
-
-    /** @var string */
-    private $cacheDir;
+    private RequestStack $requestStack;
+    private StorageManager $storageManager;
+    private UrlGeneratorInterface$urlGenerator;
+    private Processor $processor;
+    private string $cacheDir;
 
     public function __construct(RequestStack $requestStack, StorageManager $storageManager, UrlGeneratorInterface $urlGenerator, Processor $processor, string $cacheDir)
     {
@@ -39,7 +30,7 @@ class RequestRuntime implements RuntimeExtensionInterface
         $this->cacheDir = $cacheDir;
     }
 
-    public static function endsWith($haystack, $needle)
+    public static function endsWith(string $haystack, string $needle)
     {
         $length = \strlen($needle);
         if (0 == $length) {

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -30,7 +30,7 @@ class RequestRuntime implements RuntimeExtensionInterface
         $this->cacheDir = $cacheDir;
     }
 
-    public static function endsWith(string $haystack, string $needle)
+    private static function endsWith(string $haystack, string $needle)
     {
         $length = \strlen($needle);
         if (0 == $length) {

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -73,7 +73,7 @@ class RequestRuntime implements RuntimeExtensionInterface
                 if (!self::endsWith($filename, '.svg')) {
                     $filename .= '.svg';
                 }
-            } elseif (0 !== ($config[EmsFields::ASSET_CONFIG_QUALITY] ?? 0)) {
+            } elseif (0 === ($config[EmsFields::ASSET_CONFIG_QUALITY] ?? 0)) {
                 $mimeType = 'image/png';
                 if (!self::endsWith($filename, '.png')) {
                     $filename .= '.png';

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -59,27 +59,7 @@ class RequestRuntime implements RuntimeExtensionInterface
         $mimeType = $fileField[EmsFields::CONTENT_MIME_TYPE_FIELD_] ?? $fileField[$mimeTypeField] ?? MimeType::fromFilename($filename) ?? 'application/octet-stream';
 
         $mimeType = $this->processor->overwriteMimeType($mimeType, $config);
-
-        if (EmsFields::ASSET_CONFIG_TYPE_IMAGE === ($config[EmsFields::ASSET_CONFIG_TYPE] ?? null)) {
-            if ($mimeType && \preg_match('/image\/svg.*/', $mimeType)) {
-                if (MimeType::fromFilename($filename) !== $mimeType) {
-                    $filename .= '.svg';
-                }
-            } elseif (0 === ($config[EmsFields::ASSET_CONFIG_QUALITY] ?? 0)) {
-                if (MimeType::fromFilename($filename) !== $mimeType) {
-                    $filename .= '.png';
-                }
-            } else {
-                if (MimeType::fromFilename($filename) !== $mimeType) {
-                    $filename .= '.jpg';
-                }
-            }
-        }
-        if (EmsFields::ASSET_CONFIG_TYPE_ZIP === ($config[EmsFields::ASSET_CONFIG_TYPE] ?? null)) {
-            if (MimeType::fromFilename($filename) !== $mimeType) {
-                $filename .= '.zip';
-            }
-        }
+        $filename = $this->fixFileExtension($filename, $mimeType);
         $config[EmsFields::ASSET_CONFIG_MIME_TYPE] = $mimeType;
 
         try {
@@ -150,5 +130,101 @@ class RequestRuntime implements RuntimeExtensionInterface
         } catch (\Throwable $e) {
             return '#FFFFFF';
         }
+    }
+
+    private function fixFileExtension(string $filename, string $mimeType): string
+    {
+        static $mimetypes = [
+            'video/3gpp' => '3gp',
+            'application/x-7z-compressed' => '7z',
+            'audio/x-aac' => 'aac',
+            'audio/x-aiff' => 'aif',
+            'video/x-ms-asf' => 'asf',
+            'application/atom+xml' => 'atom',
+            'video/x-msvideo' => 'avi',
+            'image/bmp' => 'bmp',
+            'application/x-bzip2' => 'bz2',
+            'application/pkix-cert' => 'cer',
+            'application/pkix-crl' => 'crl',
+            'application/x-x509-ca-cert' => 'crt',
+            'text/css' => 'css',
+            'text/csv' => 'csv',
+            'application/cu-seeme' => 'cu',
+            'application/x-debian-package' => 'deb',
+            'application/msword' => 'doc',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
+            'application/x-dvi' => 'dvi',
+            'application/vnd.ms-fontobject' => 'eot',
+            'application/epub+zip' => 'epub',
+            'text/x-setext' => 'etx',
+            'audio/flac' => 'flac',
+            'video/x-flv' => 'flv',
+            'image/gif' => 'gif',
+            'application/gzip' => 'gz',
+            'text/html' => 'html',
+            'image/x-icon' => 'ico',
+            'text/calendar' => 'ics',
+            'application/x-iso9660-image' => 'iso',
+            'application/java-archive' => 'jar',
+            'image/jpeg' => 'jpeg',
+            'text/javascript' => 'js',
+            'application/json' => 'json',
+            'application/x-latex' => 'latex',
+            'audio/midi' => 'midi',
+            'video/quicktime' => 'mov',
+            'video/x-matroska' => 'mkv',
+            'audio/mpeg' => 'mp3',
+            'video/mp4' => 'mp4',
+            'audio/mp4' => 'mp4a',
+            'video/mpeg' => 'mpeg',
+            'audio/ogg' => 'ogg',
+            'video/ogg' => 'ogv',
+            'application/ogg' => 'ogx',
+            'image/x-portable-bitmap' => 'pbm',
+            'application/pdf' => 'pdf',
+            'image/x-portable-graymap' => 'pgm',
+            'image/png' => 'png',
+            'image/x-portable-anymap' => 'pnm',
+            'image/x-portable-pixmap' => 'ppm',
+            'application/vnd.ms-powerpoint' => 'ppt',
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'pptx',
+            'application/x-rar-compressed' => 'rar',
+            'image/x-cmu-raster' => 'ras',
+            'application/rss+xml' => 'rss',
+            'application/rtf' => 'rtf',
+            'text/sgml' => 'sgml',
+            'image/svg+xml' => 'svg',
+            'application/x-shockwave-flash' => 'swf',
+            'application/x-tar' => 'tar',
+            'image/tiff' => 'tiff',
+            'application/x-bittorrent' => 'torrent',
+            'application/x-font-ttf' => 'ttf',
+            'text/plain' => 'txt',
+            'audio/x-wav' => 'wav',
+            'video/webm' => 'webm',
+            'image/webp' => 'webp',
+            'audio/x-ms-wma' => 'wma',
+            'video/x-ms-wmv' => 'wmv',
+            'application/x-font-woff' => 'woff',
+            'application/wsdl+xml' => 'wsdl',
+            'image/x-xbitmap' => 'xbm',
+            'application/vnd.ms-excel' => 'xls',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx',
+            'application/xml' => 'xml',
+            'image/x-xpixmap' => 'xpm',
+            'image/x-xwindowdump' => 'xwd',
+            'text/yaml' => 'yml',
+            'application/zip' => 'zip',
+        ];
+
+        if (!isset($mimetypes[$mimeType])) {
+            return $filename;
+        }
+
+        if (MimeType::fromFilename($filename) === $mimeType) {
+            return $filename;
+        }
+
+        return \implode('.', [\pathinfo($filename, PATHINFO_FILENAME), $mimetypes[$mimeType]]);
     }
 }

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -68,7 +68,7 @@ class RequestRuntime implements RuntimeExtensionInterface
             $hashConfig = $e->getHash();
         }
 
-        if (isset($config[EmsFields::ASSET_CONFIG_GET_FILE_PATH]) && $config[EmsFields::ASSET_CONFIG_GET_FILE_PATH]) {
+        if ($config[EmsFields::ASSET_CONFIG_GET_FILE_PATH] ?? false) {
             $configObj = new Config($this->storageManager, $hash, $hashConfig, $config);
 
             $filesystem = new Filesystem();
@@ -88,13 +88,11 @@ class RequestRuntime implements RuntimeExtensionInterface
             return $cacheFilename;
         }
 
-        $parameters = [
+        return $this->urlGenerator->generate($route, [
             'hash_config' => $hashConfig,
             'filename' => \basename($filename),
             'hash' => $hash ?? $hashConfig,
-        ];
-
-        return $this->urlGenerator->generate($route, $parameters, $referenceType);
+        ], $referenceType);
     }
 
     public function assetAverageColor(string $hash): string

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -68,26 +68,25 @@ class RequestRuntime implements RuntimeExtensionInterface
             $hashConfig = $e->getHash();
         }
 
-        if ($config[EmsFields::ASSET_CONFIG_GET_FILE_PATH] ?? false) {
-            $configObj = new Config($this->storageManager, $hash, $hashConfig, $config);
-
-            $filesystem = new Filesystem();
-            $filesystem->mkdir($this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig);
-            $cacheFilename = $this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig.DIRECTORY_SEPARATOR.$hash;
-
-            if (!$filesystem->exists($cacheFilename)) {
-                $stream = $this->processor->getStream($configObj, $filename);
-                \file_put_contents($cacheFilename, $stream->getContents());
-            }
-
-            return $cacheFilename;
+        if (!($config[EmsFields::ASSET_CONFIG_GET_FILE_PATH] ?? false)) {
+            return $this->urlGenerator->generate($route, [
+                'hash_config' => $hashConfig,
+                'filename' => \basename($filename),
+                'hash' => $hash ?? $hashConfig,
+            ], $referenceType);
         }
 
-        return $this->urlGenerator->generate($route, [
-            'hash_config' => $hashConfig,
-            'filename' => \basename($filename),
-            'hash' => $hash ?? $hashConfig,
-        ], $referenceType);
+        $configObj = new Config($this->storageManager, $hash, $hashConfig, $config);
+        $filesystem = new Filesystem();
+        $filesystem->mkdir($this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig);
+        $cacheFilename = $this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig.DIRECTORY_SEPARATOR.$hash;
+
+        if (!$filesystem->exists($cacheFilename)) {
+            $stream = $this->processor->getStream($configObj, $filename);
+            \file_put_contents($cacheFilename, $stream->getContents());
+        }
+
+        return $cacheFilename;
     }
 
     public function assetAverageColor(string $hash): string

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -64,29 +64,12 @@ class RequestRuntime implements RuntimeExtensionInterface
     {
         $config = $assetConfig;
 
-        $hash = 'processor';
-        if (isset($fileField[EmsFields::CONTENT_FILE_HASH_FIELD_])) {
-            $hash = $fileField[EmsFields::CONTENT_FILE_HASH_FIELD_];
-        } elseif (isset($fileField[$fileHashField])) {
-            $hash = $fileField[$fileHashField];
-        }
-
-        $filename = 'asset.bin';
-        if (isset($fileField[EmsFields::CONTENT_FILE_NAME_FIELD_])) {
-            $filename = $fileField[EmsFields::CONTENT_FILE_NAME_FIELD_];
-        } elseif (isset($fileField[$filenameField])) {
-            $filename = $fileField[$filenameField];
-        }
-
-        $mimeType = 'application/bin';
-        if (isset($fileField[EmsFields::CONTENT_MIME_TYPE_FIELD_])) {
-            $mimeType = $fileField[EmsFields::CONTENT_MIME_TYPE_FIELD_];
-        } elseif (isset($fileField[$mimeTypeField])) {
-            $mimeType = $fileField[$mimeTypeField];
-        }
+        $hash = $fileField[EmsFields::CONTENT_FILE_HASH_FIELD_] ?? $fileField[$fileHashField] ?? 'processor';
+        $filename = $fileField[EmsFields::CONTENT_FILE_NAME_FIELD_] ?? $fileField[$filenameField] ?? 'asset.bin';
+        $mimeType = $fileField[EmsFields::CONTENT_MIME_TYPE_FIELD_] ?? $fileField[$mimeTypeField] ?? 'application/bin';
 
         //We are generating an image
-        if (isset($config[EmsFields::ASSET_CONFIG_TYPE]) && EmsFields::ASSET_CONFIG_TYPE_IMAGE === $config[EmsFields::ASSET_CONFIG_TYPE]) {
+        if (EmsFields::ASSET_CONFIG_TYPE_IMAGE === ($config[EmsFields::ASSET_CONFIG_TYPE] ?? null)) {
             //an SVG image wont be reworked
             if ($mimeType && \preg_match('/image\/svg.*/', $mimeType)) {
                 $config[EmsFields::ASSET_CONFIG_MIME_TYPE] = $mimeType;

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -3,12 +3,6 @@
 namespace EMS\CommonBundle\Twig;
 
 use EMS\CommonBundle\Helper\EmsFields;
-use EMS\CommonBundle\Storage\NotSavedException;
-use EMS\CommonBundle\Storage\Processor\Config;
-use EMS\CommonBundle\Storage\Processor\Processor;
-use EMS\CommonBundle\Storage\StorageManager;
-use GuzzleHttp\Psr7\MimeType;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Extension\RuntimeExtensionInterface;
@@ -16,18 +10,12 @@ use Twig\Extension\RuntimeExtensionInterface;
 class RequestRuntime implements RuntimeExtensionInterface
 {
     private RequestStack $requestStack;
-    private StorageManager $storageManager;
-    private UrlGeneratorInterface$urlGenerator;
-    private Processor $processor;
-    private string $cacheDir;
+    private AssetRuntime $assetRuntime;
 
-    public function __construct(RequestStack $requestStack, StorageManager $storageManager, UrlGeneratorInterface $urlGenerator, Processor $processor, string $cacheDir)
+    public function __construct(RequestStack $requestStack, AssetRuntime $assetRuntime)
     {
         $this->requestStack = $requestStack;
-        $this->storageManager = $storageManager;
-        $this->urlGenerator = $urlGenerator;
-        $this->processor = $processor;
-        $this->cacheDir = $cacheDir;
+        $this->assetRuntime = $assetRuntime;
     }
 
     /**
@@ -46,177 +34,25 @@ class RequestRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * @param string $filenameField
-     * @param string $mimeTypeField
-     * @param int    $referenceType
+     * @deprecated assetPath will be removed in elasticms/common-bundle 1.20. Use AssetRuntime::assetPath instead.
+     *
+     * @param array<string, mixed> $fileField
+     * @param array<string, mixed> $assetConfig
      */
-    public function assetPath(array $fileField, array $assetConfig = [], string $route = 'ems_asset', string $fileHashField = EmsFields::CONTENT_FILE_HASH_FIELD, $filenameField = EmsFields::CONTENT_FILE_NAME_FIELD, $mimeTypeField = EmsFields::CONTENT_MIME_TYPE_FIELD, $referenceType = UrlGeneratorInterface::RELATIVE_PATH): string
+    public function assetPath(array $fileField, array $assetConfig = [], string $route = 'ems_asset', string $fileHashField = EmsFields::CONTENT_FILE_HASH_FIELD, string $filenameField = EmsFields::CONTENT_FILE_NAME_FIELD, string $mimeTypeField = EmsFields::CONTENT_MIME_TYPE_FIELD, int $referenceType = UrlGeneratorInterface::RELATIVE_PATH): string
     {
-        $config = $assetConfig;
+        \trigger_error('assetPath will be removed in elasticms/common-bundle 1.20. Use AssetRuntime::assetPath instead.', E_USER_DEPRECATED);
 
-        $hash = $fileField[EmsFields::CONTENT_FILE_HASH_FIELD_] ?? $fileField[$fileHashField] ?? 'processor';
-        $filename = $fileField[EmsFields::CONTENT_FILE_NAME_FIELD_] ?? $fileField[$filenameField] ?? 'asset.bin';
-        $mimeType = $fileField[EmsFields::CONTENT_MIME_TYPE_FIELD_] ?? $fileField[$mimeTypeField] ?? MimeType::fromFilename($filename) ?? 'application/octet-stream';
-
-        $mimeType = $this->processor->overwriteMimeType($mimeType, $config);
-        $filename = $this->fixFileExtension($filename, $mimeType);
-        $config[EmsFields::ASSET_CONFIG_MIME_TYPE] = $mimeType;
-
-        try {
-            $hashConfig = $this->storageManager->saveConfig($config);
-        } catch (NotSavedException $e) {
-            $hashConfig = $e->getHash();
-        }
-
-        if (!($config[EmsFields::ASSET_CONFIG_GET_FILE_PATH] ?? false)) {
-            return $this->urlGenerator->generate($route, [
-                'hash_config' => $hashConfig,
-                'filename' => \basename($filename),
-                'hash' => $hash ?? $hashConfig,
-            ], $referenceType);
-        }
-
-        $configObj = new Config($this->storageManager, $hash, $hashConfig, $config);
-        $filesystem = new Filesystem();
-        $filesystem->mkdir($this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig);
-        $cacheFilename = $this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig.DIRECTORY_SEPARATOR.$hash;
-
-        if (!$filesystem->exists($cacheFilename)) {
-            $stream = $this->processor->getStream($configObj, $filename);
-            \file_put_contents($cacheFilename, $stream->getContents());
-        }
-
-        return $cacheFilename;
+        return $this->assetRuntime->assetPath($fileField, $assetConfig, $route, $fileHashField, $filenameField, $mimeTypeField, $referenceType);
     }
 
+    /**
+     * @deprecated assetAverageColor will be removed in elasticms/common-bundle 1.20. Use AssetRuntime::assetAverageColor instead.
+     */
     public function assetAverageColor(string $hash): string
     {
-        try {
-            $config = $this->processor->configFactory($hash, [
-                EmsFields::ASSET_CONFIG_TYPE => EmsFields::ASSET_CONFIG_TYPE_IMAGE,
-                EmsFields::ASSET_CONFIG_RESIZE => 'free',
-                EmsFields::ASSET_CONFIG_WIDTH => 1,
-                EmsFields::ASSET_CONFIG_HEIGHT => 1,
-                EmsFields::ASSET_CONFIG_QUALITY => 80,
-                EmsFields::ASSET_CONFIG_MIME_TYPE => 'image/jpeg',
-            ]);
-            $stream = $this->processor->getStream($config, 'one-pixel.jpg');
+        \trigger_error('assetAverageColor will be removed in elasticms/common-bundle 1.20. Use AssetRuntime::assetAverageColor instead.', E_USER_DEPRECATED);
 
-            $image = \imagecreatefromstring($stream->getContents());
-            if (false === $image) {
-                throw new \RuntimeException('Unexpected imagecreatefromstring error');
-            }
-            $index = \imagecolorat($image, 0, 0);
-            if (false === $index) {
-                throw new \RuntimeException('Unexpected imagecolorat error');
-            }
-            $rgb = \imagecolorsforindex($image, $index);
-            if (false === $rgb) {
-                throw new \RuntimeException('Unexpected imagecolorsforindex error');
-            }
-            $red = \round(\round((($rgb['red'] ?? 255) / 0x33)) * 0x33);
-            $green = \round(\round((($rgb['green'] ?? 255) / 0x33)) * 0x33);
-            $blue = \round(\round((($rgb['blue'] ?? 255) / 0x33)) * 0x33);
-
-            return \sprintf('#%02X%02X%02X', $red, $green, $blue);
-        } catch (\Throwable $e) {
-            return '#FFFFFF';
-        }
-    }
-
-    private function fixFileExtension(string $filename, string $mimeType): string
-    {
-        static $mimetypes = [
-            'video/3gpp' => '3gp',
-            'application/x-7z-compressed' => '7z',
-            'audio/x-aac' => 'aac',
-            'audio/x-aiff' => 'aif',
-            'video/x-ms-asf' => 'asf',
-            'application/atom+xml' => 'atom',
-            'video/x-msvideo' => 'avi',
-            'image/bmp' => 'bmp',
-            'application/x-bzip2' => 'bz2',
-            'application/pkix-cert' => 'cer',
-            'application/pkix-crl' => 'crl',
-            'application/x-x509-ca-cert' => 'crt',
-            'text/css' => 'css',
-            'text/csv' => 'csv',
-            'application/cu-seeme' => 'cu',
-            'application/x-debian-package' => 'deb',
-            'application/msword' => 'doc',
-            'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
-            'application/x-dvi' => 'dvi',
-            'application/vnd.ms-fontobject' => 'eot',
-            'application/epub+zip' => 'epub',
-            'text/x-setext' => 'etx',
-            'audio/flac' => 'flac',
-            'video/x-flv' => 'flv',
-            'image/gif' => 'gif',
-            'application/gzip' => 'gz',
-            'text/html' => 'html',
-            'image/x-icon' => 'ico',
-            'text/calendar' => 'ics',
-            'application/x-iso9660-image' => 'iso',
-            'application/java-archive' => 'jar',
-            'image/jpeg' => 'jpeg',
-            'text/javascript' => 'js',
-            'application/json' => 'json',
-            'application/x-latex' => 'latex',
-            'audio/midi' => 'midi',
-            'video/quicktime' => 'mov',
-            'video/x-matroska' => 'mkv',
-            'audio/mpeg' => 'mp3',
-            'video/mp4' => 'mp4',
-            'audio/mp4' => 'mp4a',
-            'video/mpeg' => 'mpeg',
-            'audio/ogg' => 'ogg',
-            'video/ogg' => 'ogv',
-            'application/ogg' => 'ogx',
-            'image/x-portable-bitmap' => 'pbm',
-            'application/pdf' => 'pdf',
-            'image/x-portable-graymap' => 'pgm',
-            'image/png' => 'png',
-            'image/x-portable-anymap' => 'pnm',
-            'image/x-portable-pixmap' => 'ppm',
-            'application/vnd.ms-powerpoint' => 'ppt',
-            'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'pptx',
-            'application/x-rar-compressed' => 'rar',
-            'image/x-cmu-raster' => 'ras',
-            'application/rss+xml' => 'rss',
-            'application/rtf' => 'rtf',
-            'text/sgml' => 'sgml',
-            'image/svg+xml' => 'svg',
-            'application/x-shockwave-flash' => 'swf',
-            'application/x-tar' => 'tar',
-            'image/tiff' => 'tiff',
-            'application/x-bittorrent' => 'torrent',
-            'application/x-font-ttf' => 'ttf',
-            'text/plain' => 'txt',
-            'audio/x-wav' => 'wav',
-            'video/webm' => 'webm',
-            'image/webp' => 'webp',
-            'audio/x-ms-wma' => 'wma',
-            'video/x-ms-wmv' => 'wmv',
-            'application/x-font-woff' => 'woff',
-            'application/wsdl+xml' => 'wsdl',
-            'image/x-xbitmap' => 'xbm',
-            'application/vnd.ms-excel' => 'xls',
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx',
-            'application/xml' => 'xml',
-            'image/x-xpixmap' => 'xpm',
-            'image/x-xwindowdump' => 'xwd',
-            'text/yaml' => 'yml',
-            'application/zip' => 'zip',
-        ];
-
-        if (!isset($mimetypes[$mimeType])) {
-            return $filename;
-        }
-
-        if (MimeType::fromFilename($filename) === $mimeType) {
-            return $filename;
-        }
-
-        return \implode('.', [\pathinfo($filename, PATHINFO_FILENAME), $mimetypes[$mimeType]]);
+        return $this->assetRuntime->assetAverageColor($hash);
     }
 }

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -72,13 +72,8 @@ class RequestRuntime implements RuntimeExtensionInterface
             $configObj = new Config($this->storageManager, $hash, $hashConfig, $config);
 
             $filesystem = new Filesystem();
-            if ($hash) {
-                $filesystem->mkdir($this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig);
-                $cacheFilename = $this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig.DIRECTORY_SEPARATOR.$hash;
-            } else {
-                $filesystem->mkdir($this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path');
-                $cacheFilename = $this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig;
-            }
+            $filesystem->mkdir($this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig);
+            $cacheFilename = $this->cacheDir.DIRECTORY_SEPARATOR.'ems_asset_path'.DIRECTORY_SEPARATOR.$hashConfig.DIRECTORY_SEPARATOR.$hash;
 
             if (!$filesystem->exists($cacheFilename)) {
                 $stream = $this->processor->getStream($configObj, $filename);

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -7,7 +7,7 @@ use EMS\CommonBundle\Storage\NotSavedException;
 use EMS\CommonBundle\Storage\Processor\Config;
 use EMS\CommonBundle\Storage\Processor\Processor;
 use EMS\CommonBundle\Storage\StorageManager;
-use function GuzzleHttp\Psr7\mimetype_from_filename;
+use GuzzleHttp\Psr7\MimeType;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -105,7 +105,7 @@ class RequestRuntime implements RuntimeExtensionInterface
                 }
             }
         } elseif (!$mimeType) {
-            $config[EmsFields::ASSET_CONFIG_MIME_TYPE] = mimetype_from_filename($filename) ?? 'application/octet-stream';
+            $config[EmsFields::ASSET_CONFIG_MIME_TYPE] = MimeType::fromFilename($filename) ?? 'application/octet-stream';
         } else {
             $config[EmsFields::ASSET_CONFIG_MIME_TYPE] = $mimeType;
         }

--- a/src/Twig/RequestRuntime.php
+++ b/src/Twig/RequestRuntime.php
@@ -19,9 +19,11 @@ class RequestRuntime implements RuntimeExtensionInterface
     }
 
     /**
+     * @param array<mixed> $source
+     *
      * @return mixed
      */
-    public function localeAttribute(array $array, string $attribute)
+    public function localeAttribute(array $source, string $attribute)
     {
         $request = $this->requestStack->getCurrentRequest();
         if (null === $request) {
@@ -30,7 +32,7 @@ class RequestRuntime implements RuntimeExtensionInterface
 
         $locale = $request->getLocale();
 
-        return isset($array[$attribute.$locale]) ? $array[$attribute.$locale] : '';
+        return isset($source[$attribute.$locale]) ? $source[$attribute.$locale] : '';
     }
 
     /**

--- a/src/Twig/TextRuntime.php
+++ b/src/Twig/TextRuntime.php
@@ -4,15 +4,14 @@ namespace EMS\CommonBundle\Twig;
 
 use EMS\CommonBundle\Helper\Text\Encoder;
 use EMS\CommonBundle\Json\Decoder;
+use EMS\CommonBundle\Json\JsonMenu;
 use EMS\CommonBundle\Json\JsonMenuNested;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class TextRuntime implements RuntimeExtensionInterface
 {
-    /** @var Encoder */
-    private $encoder;
-    /** @var Decoder */
-    private $decoder;
+    private Encoder $encoder;
+    private Decoder $decoder;
 
     public function __construct(Encoder $encoder, Decoder $decoder)
     {
@@ -20,17 +19,17 @@ class TextRuntime implements RuntimeExtensionInterface
         $this->decoder = $decoder;
     }
 
-    public function htmlEncode(string $text)
+    public function htmlEncode(string $text): string
     {
         return $this->encoder->htmlEncode($text);
     }
 
-    public function htmlEncodePii(string $text)
+    public function htmlEncodePii(string $text): string
     {
         return $this->encoder->htmlEncodePii($text);
     }
 
-    public function jsonMenuDecode(string $json, string $glue = '/')
+    public function jsonMenuDecode(string $json, string $glue = '/'): JsonMenu
     {
         return $this->decoder->jsonMenuDecode($json, $glue);
     }
@@ -40,6 +39,9 @@ class TextRuntime implements RuntimeExtensionInterface
         return $this->decoder->jsonMenuNestedDecode($json);
     }
 
+    /**
+     * @return mixed
+     */
     public function jsonDecode(string $json, bool $assoc = true, int $depth = 512, int $options = 0)
     {
         return \json_decode($json, $assoc, $depth, $options);


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |y|	

# New feature

- _mime_type config attribute can be used to override the file field's mimetype

# Fixed tickets

- close #70
