### PR TITLE
feat: s3 upload folder

### DIFF
--- a/doc/storages.md
+++ b/doc/storages.md
@@ -113,6 +113,7 @@ The will instantiate a S3 client service to read/save assets in a S3 (or a s3-li
  - `credentials` (mandatory): S3 credential object
  - `bucket` (mandatory): Name of the bucket to use
  - `usage` Default value: `"cache"`
+ - `upload-folder` Default value: `null`. As S3 doesn't support appending chunks the performances of this services decrease with large files. You may be interested to upload files in a local folder first. That folder must be shared between your instances or at least sessions must associate to one instance (i.e. via a sticky session cookie).  
  
  Example:
  ```yaml

--- a/src/Storage/Factory/S3Factory.php
+++ b/src/Storage/Factory/S3Factory.php
@@ -10,14 +10,11 @@ use Psr\Log\LoggerInterface;
 
 class S3Factory extends AbstractFactory implements StorageFactoryInterface
 {
-    /** @var string */
     public const STORAGE_TYPE = 's3';
-    /** @var string */
     public const STORAGE_CONFIG_CREDENTIALS = 'credentials';
-    /** @var string */
     public const STORAGE_CONFIG_BUCKET = 'bucket';
-    /** @var LoggerInterface */
-    private $logger;
+    public const STORAGE_CONFIG_UPLOAD_FOLDER = 'upload-folder';
+    private LoggerInterface $logger;
 
     public function __construct(LoggerInterface $logger)
     {
@@ -37,7 +34,7 @@ class S3Factory extends AbstractFactory implements StorageFactoryInterface
             return null;
         }
 
-        return new S3Storage($this->logger, $credentials, $bucket, $config[self::STORAGE_CONFIG_USAGE], $config[self::STORAGE_CONFIG_HOT_SYNCHRONIZE_LIMIT]);
+        return new S3Storage($this->logger, $credentials, $bucket, $config[self::STORAGE_CONFIG_USAGE], $config[self::STORAGE_CONFIG_HOT_SYNCHRONIZE_LIMIT], $config[self::STORAGE_CONFIG_UPLOAD_FOLDER]);
     }
 
     public function getStorageType(): string
@@ -48,7 +45,7 @@ class S3Factory extends AbstractFactory implements StorageFactoryInterface
     /**
      * @param array<string, mixed> $parameters
      *
-     * @return array{type: string, credentials: null|array, bucket: null|string, usage: int, hot-synchronize-limit: int}
+     * @return array{type: string, credentials: null|array, bucket: null|string, usage: int, hot-synchronize-limit: int, upload-folder: null|string}
      */
     private function resolveParameters(array $parameters): array
     {
@@ -58,12 +55,14 @@ class S3Factory extends AbstractFactory implements StorageFactoryInterface
                 self::STORAGE_CONFIG_TYPE => self::STORAGE_TYPE,
                 self::STORAGE_CONFIG_CREDENTIALS => null,
                 self::STORAGE_CONFIG_BUCKET => null,
+                self::STORAGE_CONFIG_UPLOAD_FOLDER => null,
             ])
             ->setAllowedTypes(self::STORAGE_CONFIG_CREDENTIALS, ['null', 'array'])
             ->setAllowedTypes(self::STORAGE_CONFIG_BUCKET, ['null', 'string'])
+            ->setAllowedTypes(self::STORAGE_CONFIG_UPLOAD_FOLDER, ['null', 'string'])
             ->setAllowedValues(self::STORAGE_CONFIG_TYPE, [self::STORAGE_TYPE])
         ;
-        /** @var array{type: string, credentials: null|array, bucket: null|string, usage: int, hot-synchronize-limit: int} $resolvedParameter */
+        /** @var array{type: string, credentials: null|array, bucket: null|string, usage: int, hot-synchronize-limit: int, upload-folder: null|string} $resolvedParameter */
         $resolvedParameter = $resolver->resolve($parameters);
 
         return $resolvedParameter;

--- a/src/Storage/Service/S3Storage.php
+++ b/src/Storage/Service/S3Storage.php
@@ -17,15 +17,17 @@ class S3Storage extends AbstractUrlStorage
 
     /** @var array{version?:string,credentials?:array{key:string,secret:string},region?:string} */
     private $credentials;
+    private ?string $uploadFolder;
 
     /**
      * @param array{version?:string,credentials?:array{key:string,secret:string},region?:string} $s3Credentials
      */
-    public function __construct(LoggerInterface $logger, array $s3Credentials, string $s3Bucket, int $usage, int $hotSynchronizeLimit = 0)
+    public function __construct(LoggerInterface $logger, array $s3Credentials, string $s3Bucket, int $usage, int $hotSynchronizeLimit = 0, string $uploadFolder = null)
     {
         parent::__construct($logger, $usage, $hotSynchronizeLimit);
         $this->bucket = $s3Bucket;
         $this->credentials = $s3Credentials;
+        $this->uploadFolder = $uploadFolder;
     }
 
     protected function getBaseUrl(): string

--- a/src/Storage/Service/S3Storage.php
+++ b/src/Storage/Service/S3Storage.php
@@ -6,7 +6,6 @@ namespace EMS\CommonBundle\Storage\Service;
 
 use Aws\S3\S3Client;
 use EMS\CommonBundle\Common\Standard\Json;
-use GuzzleHttp\Psr7\Stream;
 use Psr\Log\LoggerInterface;
 
 class S3Storage extends AbstractUrlStorage

--- a/src/Storage/Service/S3Storage.php
+++ b/src/Storage/Service/S3Storage.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace EMS\CommonBundle\Storage\Service;
 
 use Aws\S3\S3Client;
+use EMS\CommonBundle\Common\Standard\Json;
+use GuzzleHttp\Psr7\Stream;
 use Psr\Log\LoggerInterface;
 
 class S3Storage extends AbstractUrlStorage
@@ -18,6 +20,7 @@ class S3Storage extends AbstractUrlStorage
     /** @var array{version?:string,credentials?:array{key:string,secret:string},region?:string} */
     private $credentials;
     private ?string $uploadFolder;
+    private ?string $bucketHash = null;
 
     /**
      * @param array{version?:string,credentials?:array{key:string,secret:string},region?:string} $s3Credentials
@@ -45,8 +48,25 @@ class S3Storage extends AbstractUrlStorage
         return S3Storage::class." ($this->bucket)";
     }
 
+    protected function getUploadPath(string $hash, string $ds = '/'): string
+    {
+        if (null === $this->uploadFolder) {
+            return parent::getUploadPath($hash, $ds);
+        }
+
+        return \join($ds, [
+            $this->uploadFolder,
+            $this->getBucketHash(),
+            $hash,
+        ]);
+    }
+
     public function initUpload(string $hash, int $size, string $name, string $type): bool
     {
+        if (null !== $this->uploadFolder) {
+            return parent::initUpload($hash, $size, $name, $type);
+        }
+
         $path = $this->getUploadPath($hash);
         $this->initDirectory($path);
         $result = $this->s3Client->putObject([
@@ -64,13 +84,33 @@ class S3Storage extends AbstractUrlStorage
     {
         $source = $this->getUploadPath($hash);
         $destination = $this->getPath($hash);
-        \copy($source, $destination);
+        $result = \copy($source, $destination);
+        $this->removeUpload($hash);
 
+        return $result;
+    }
+
+    private function getBucketHash(): string
+    {
+        if (null !== $this->bucketHash) {
+            return $this->bucketHash;
+        }
+        $this->bucketHash = \sha1(\sprintf('s3_%s_%s', $this->bucket, Json::encode($this->credentials)));
+
+        return $this->bucketHash;
+    }
+
+    public function removeUpload(string $hash): void
+    {
+        if (null !== $this->uploadFolder) {
+            parent::removeUpload($hash);
+
+            return;
+        }
+        $source = $this->getUploadPath($hash);
         $this->s3Client->deleteObject([
             'Bucket' => $this->bucket,
             'Key' => \substr($source, 1 + \strlen($this->getBaseUrl())),
         ]);
-
-        return true;
     }
 }

--- a/src/Storage/StorageManager.php
+++ b/src/Storage/StorageManager.php
@@ -189,6 +189,16 @@ class StorageManager
         return $hashFile;
     }
 
+    public function computeStreamHash(StreamInterface $handler): string
+    {
+        $hashContext = \hash_init($this->hashAlgo);
+        while (!$handler->eof()) {
+            \hash_update($hashContext, $handler->read(1024 * 1024));
+        }
+
+        return \hash_final($hashContext);
+    }
+
     public function initUploadFile(string $fileHash, int $fileSize, string $fileName, string $mimeType, int $usageType): int
     {
         $count = 0;
@@ -285,7 +295,7 @@ class StorageManager
             if (null === $uploadedSize) {
                 continue;
             }
-            $computedHash = $this->computeStringHash($handler->getContents());
+            $computedHash = $this->computeStreamHash($handler);
 
             if ($computedHash !== $hash) {
                 $adapter->removeUpload($hash);


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |y|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

# Feature
- add an upload-folder option to the S3 storage service

# Fix
- Memory leak on finalise upload (switched to a streamed hash compute instead of loading the uploaded file in a string)