### PR TITLE
fix: align serializer to symfony 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
 		"symfony/options-resolver": "^4.4",
 		"symfony/routing": "^4.4",
 		"symfony/security": "^4.4",
-		"symfony/serializer": "^5.3",
+		"symfony/serializer": "^4.4",
 		"symfony/stopwatch": "^4.4",
 		"symfony/translation": "^4.4",
 		"twig/twig": "^2.14"

--- a/src/Search/Search.php
+++ b/src/Search/Search.php
@@ -58,6 +58,9 @@ class Search
     public static function deserialize(string $data, string $format = 'json'): Search
     {
         $data = self::getSerializer()->deserialize($data, Search::class, $format);
+        if (!$data instanceof Search) {
+            throw new \RuntimeException('Unexpected search object');
+        }
 
         return $data;
     }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Wrong version of symfony/serializer