### PR TITLE
fix: ensure that the config hash change if the file change

### DIFF
--- a/doc/processors.md
+++ b/doc/processors.md
@@ -57,7 +57,8 @@ And in this sample il will generate an url to a file on the sever file system:
 ```twig
 <a href="{{ ems_asset_path({
    filename: 'Rapport.pdf',
-   mimetype: 'application/pdf'
+   mimetype: 'application/pdf',
+   sha1: 'dummy'
 }, {
    _file_names: [
        '/opt/files/rapport.pdf',

--- a/src/Helper/EmsFields.php
+++ b/src/Helper/EmsFields.php
@@ -44,6 +44,7 @@ final class EmsFields
     public const ASSET_CONFIG_PASSWORD = '_password';
     public const ASSET_CONFIG_AFTER = '_after';
     public const ASSET_CONFIG_BEFORE = '_before';
+    public const ASSET_SEED = '_seed';
 
     public const LOG_ALIAS = 'ems_internal_logger_alias';
     public const LOG_TYPE = 'doc';

--- a/src/Storage/Processor/Config.php
+++ b/src/Storage/Processor/Config.php
@@ -337,6 +337,7 @@ final class Config
             ->setAllowedTypes(EmsFields::ASSET_CONFIG_FLIP_VERTICAL, ['bool'])
             ->setAllowedTypes(EmsFields::ASSET_CONFIG_FLIP_HORIZONTAL, ['bool'])
             ->setAllowedTypes(EmsFields::ASSET_CONFIG_USERNAME, ['string', 'null'])
+            ->setAllowedTypes(EmsFields::ASSET_SEED, ['string', 'null'])
             ->setAllowedTypes(EmsFields::ASSET_CONFIG_PASSWORD, ['string', 'null'])
             ->setAllowedTypes(EmsFields::ASSET_CONFIG_BEFORE, ['string', 'int'])
             ->setAllowedTypes(EmsFields::ASSET_CONFIG_AFTER, ['string', 'int'])
@@ -395,6 +396,7 @@ final class Config
             EmsFields::ASSET_CONFIG_PASSWORD => null,
             EmsFields::ASSET_CONFIG_BEFORE => 0,
             EmsFields::ASSET_CONFIG_AFTER => 0,
+            EmsFields::ASSET_SEED => null,
         ];
     }
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

ems_asset_path returns immutable routes, so if the _file_names is define in ordre to use a local file, the config file must reflects the file signature. So the config hash will change if the file chamge.