### PR TITLE
feat: update wo json path

### DIFF
--- a/src/Command/Admin/GetCommand.php
+++ b/src/Command/Admin/GetCommand.php
@@ -21,14 +21,14 @@ class GetCommand extends AbstractCommand
     private AdminHelper $adminHelper;
     private string $configType;
     private bool $export;
-    private string $folder = 'admin';
+    private string $folder;
     private CoreApiInterface $coreApi;
 
     public function __construct(AdminHelper $adminHelper, string $projectFolder)
     {
         parent::__construct();
         $this->adminHelper = $adminHelper;
-        $this->folder = $projectFolder.DIRECTORY_SEPARATOR.$this->folder;
+        $this->folder = $projectFolder.DIRECTORY_SEPARATOR.ConfigHelper::DEFAULT_FOLDER;
     }
 
     public function initialize(InputInterface $input, OutputInterface $output): void
@@ -36,8 +36,10 @@ class GetCommand extends AbstractCommand
         parent::initialize($input, $output);
         $this->configType = $this->getArgumentString(self::CONFIG_TYPE);
         $this->export = $this->getOptionBool(self::EXPORT);
-        $this->folder = $this->getOptionString(self::FOLDER);
-        $this->coreApi = $this->adminHelper->getCoreApi();
+        $folder = $this->getOptionStringNull(self::FOLDER);
+        if (null !== $folder) {
+            $this->folder = $folder;
+        }
     }
 
     protected function configure(): void
@@ -45,11 +47,12 @@ class GetCommand extends AbstractCommand
         parent::configure();
         $this->addArgument(self::CONFIG_TYPE, InputArgument::REQUIRED, \sprintf('Type of configs to get'));
         $this->addOption(self::EXPORT, null, InputOption::VALUE_NONE, 'Export configs in JSON files');
-        $this->addOption(self::FOLDER, null, InputOption::VALUE_OPTIONAL, 'Export folder', $this->folder);
+        $this->addOption(self::FOLDER, null, InputOption::VALUE_OPTIONAL, 'Export folder');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->coreApi = $this->adminHelper->getCoreApi();
         $this->io->title('Admin - get');
         $this->io->section(\sprintf('Getting %s\'s configurations from %s', $this->configType, $this->coreApi->getBaseUrl()));
 

--- a/src/Command/Admin/GetCommand.php
+++ b/src/Command/Admin/GetCommand.php
@@ -36,6 +36,7 @@ class GetCommand extends AbstractCommand
         parent::initialize($input, $output);
         $this->configType = $this->getArgumentString(self::CONFIG_TYPE);
         $this->export = $this->getOptionBool(self::EXPORT);
+        $this->folder = $this->getOptionString(self::FOLDER);
         $this->coreApi = $this->adminHelper->getCoreApi();
     }
 

--- a/src/Command/Admin/UpdateCommand.php
+++ b/src/Command/Admin/UpdateCommand.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace EMS\CommonBundle\Command\Admin;
 
 use EMS\CommonBundle\Common\Admin\AdminHelper;
+use EMS\CommonBundle\Common\Admin\ConfigHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Common\Standard\Json;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateCommand extends AbstractCommand
@@ -16,15 +18,18 @@ class UpdateCommand extends AbstractCommand
     public const CONFIG_TYPE = 'config-type';
     public const ENTITY_NAME = 'entity-name';
     public const JSON_PATH = 'json-path';
+    public const FOLDER = 'folder';
     private string $configType;
     private string $entityName;
-    private string $jsonPath;
+    private ?string $jsonPath;
     private AdminHelper $adminHelper;
+    private string $folder;
 
-    public function __construct(AdminHelper $adminHelper)
+    public function __construct(AdminHelper $adminHelper, string $projectFolder)
     {
         parent::__construct();
         $this->adminHelper = $adminHelper;
+        $this->folder = $projectFolder.DIRECTORY_SEPARATOR.ConfigHelper::DEFAULT_FOLDER;
     }
 
     public function initialize(InputInterface $input, OutputInterface $output): void
@@ -32,7 +37,11 @@ class UpdateCommand extends AbstractCommand
         parent::initialize($input, $output);
         $this->configType = $this->getArgumentString(self::CONFIG_TYPE);
         $this->entityName = $this->getArgumentString(self::ENTITY_NAME);
-        $this->jsonPath = $this->getArgumentString(self::JSON_PATH);
+        $this->jsonPath = $this->getArgumentStringNull(self::JSON_PATH);
+        $folder = $this->getOptionStringNull(self::FOLDER);
+        if (null !== $folder) {
+            $this->folder = $folder;
+        }
     }
 
     protected function configure(): void
@@ -40,7 +49,8 @@ class UpdateCommand extends AbstractCommand
         parent::configure();
         $this->addArgument(self::CONFIG_TYPE, InputArgument::REQUIRED, 'Type of config to update');
         $this->addArgument(self::ENTITY_NAME, InputArgument::REQUIRED, 'Entity\'s name to update');
-        $this->addArgument(self::JSON_PATH, InputArgument::REQUIRED, 'Path to the JSON file');
+        $this->addArgument(self::JSON_PATH, InputArgument::OPTIONAL, 'Path to the JSON file');
+        $this->addOption(self::FOLDER, null, InputOption::VALUE_OPTIONAL, 'Export folder');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -53,6 +63,11 @@ class UpdateCommand extends AbstractCommand
             return self::EXECUTE_ERROR;
         }
         $configApi = $this->adminHelper->getCoreApi()->admin()->getConfig($this->configType);
+        $configHelper = new ConfigHelper($configApi, $this->folder);
+        if (null === $this->jsonPath) {
+            $this->jsonPath = $configHelper->getFilename($this->entityName);
+        }
+
         $fileContent = \file_get_contents($this->jsonPath);
         if (!\is_string($fileContent)) {
             throw new \RuntimeException('Unexpected non string file content');

--- a/src/Common/Admin/ConfigHelper.php
+++ b/src/Common/Admin/ConfigHelper.php
@@ -11,6 +11,7 @@ use Symfony\Component\Finder\SplFileInfo;
 
 final class ConfigHelper
 {
+    public const DEFAULT_FOLDER = 'admin';
     private string $directory;
     private ConfigInterface $config;
 
@@ -44,6 +45,11 @@ final class ConfigHelper
      */
     public function save(string $name, array $config): void
     {
-        \file_put_contents($this->directory.DIRECTORY_SEPARATOR.$name.'.json', Json::encode($config, true));
+        \file_put_contents($this->getFilename($name), Json::encode($config, true));
+    }
+
+    public function getFilename(string $name): string
+    {
+        return $this->directory.DIRECTORY_SEPARATOR.$name.'.json';
     }
 }

--- a/src/Common/Command/AbstractCommand.php
+++ b/src/Common/Command/AbstractCommand.php
@@ -71,6 +71,15 @@ abstract class AbstractCommand extends Command implements CommandInterface
         return \strval($arg);
     }
 
+    protected function getArgumentStringNull(string $name): ?string
+    {
+        if (null === $arg = $this->input->getArgument($name)) {
+            return null;
+        }
+
+        return \strval($arg);
+    }
+
     /**
      * @return string[]
      */

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -34,6 +34,7 @@
         </service>
         <service id="ems.command.admin.update" class="EMS\CommonBundle\Command\Admin\UpdateCommand">
             <argument type="service" id="ems.helper.admin_api"/>
+            <argument type="string">%kernel.project_dir%</argument>
             <tag name="console.command" command="ems:admin:update"/>
         </service>
     </services>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |y|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

get a default json filename from /opt/src/admin/%config-type%/%entity-name%.json in order to have simplier command: `ems:admin:update content-type route`