### PR TITLE
fix: admin login url last argument

### DIFF
--- a/src/Command/Admin/LoginCommand.php
+++ b/src/Command/Admin/LoginCommand.php
@@ -34,7 +34,7 @@ class LoginCommand extends AbstractCommand
         $this
             ->addArgument(self::ARG_BASE_URL, InputArgument::OPTIONAL, 'Elasticms base url (default: EMS_BACKEND_URL)')
             ->addOption(self::OPTION_USERNAME, 'u', InputOption::VALUE_REQUIRED, 'username')
-            ->addOption(self::OPTION_PASSWORD, 'p', InputOption::VALUE_REQUIRED, 'username')
+            ->addOption(self::OPTION_PASSWORD, 'p', InputOption::VALUE_REQUIRED, 'password')
         ;
     }
 

--- a/src/Command/Admin/LoginCommand.php
+++ b/src/Command/Admin/LoginCommand.php
@@ -9,14 +9,15 @@ use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Contracts\CoreApi\Exception\NotAuthenticatedExceptionInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
 class LoginCommand extends AbstractCommand
 {
     private const ARG_BASE_URL = 'base-url';
-    private const ARG_USERNAME = 'username';
-    private const ARG_PASSWORD = 'password';
+    private const OPTION_USERNAME = 'username';
+    private const OPTION_PASSWORD = 'password';
     private AdminHelper $adminHelper;
     private ?string $backendUrl;
 
@@ -31,9 +32,9 @@ class LoginCommand extends AbstractCommand
     {
         parent::configure();
         $this
-            ->addArgument(self::ARG_USERNAME, InputArgument::OPTIONAL, 'username')
-            ->addArgument(self::ARG_PASSWORD, InputArgument::OPTIONAL, 'password')
             ->addArgument(self::ARG_BASE_URL, InputArgument::OPTIONAL, 'Elasticms base url (default: EMS_BACKEND_URL)')
+            ->addOption(self::OPTION_USERNAME, 'u', InputOption::VALUE_REQUIRED, 'username')
+            ->addOption(self::OPTION_PASSWORD, 'p', InputOption::VALUE_REQUIRED, 'username')
         ;
     }
 
@@ -43,12 +44,12 @@ class LoginCommand extends AbstractCommand
             $this->backendUrl = \strval($this->io->askQuestion(new Question('Elasticm\'s URL')));
         }
 
-        if (null === $input->getArgument(self::ARG_USERNAME)) {
-            $input->setArgument(self::ARG_USERNAME, $this->io->askQuestion(new Question('Username')));
+        if (null === $input->getOption(self::OPTION_USERNAME)) {
+            $input->setOption(self::OPTION_USERNAME, $this->io->askQuestion(new Question('Username')));
         }
 
-        if (null === $input->getArgument(self::ARG_PASSWORD)) {
-            $input->setArgument(self::ARG_PASSWORD, $this->io->askHidden('Password'));
+        if (null === $input->getOption(self::OPTION_PASSWORD)) {
+            $input->setOption(self::OPTION_PASSWORD, $this->io->askHidden('Password'));
         }
     }
 
@@ -71,8 +72,8 @@ class LoginCommand extends AbstractCommand
         try {
             $coreApi = $this->adminHelper->login(
                 $this->backendUrl,
-                $this->getArgumentString(self::ARG_USERNAME),
-                $this->getArgumentString(self::ARG_PASSWORD)
+                $this->getOptionString(self::OPTION_USERNAME),
+                $this->getOptionString(self::OPTION_PASSWORD)
             );
         } catch (NotAuthenticatedExceptionInterface $e) {
             $this->io->error('Invalid credentials!');

--- a/src/Command/Admin/LoginCommand.php
+++ b/src/Command/Admin/LoginCommand.php
@@ -31,9 +31,9 @@ class LoginCommand extends AbstractCommand
     {
         parent::configure();
         $this
-            ->addArgument(self::ARG_BASE_URL, InputArgument::OPTIONAL, 'Elasticms\'s base url')
             ->addArgument(self::ARG_USERNAME, InputArgument::OPTIONAL, 'username')
             ->addArgument(self::ARG_PASSWORD, InputArgument::OPTIONAL, 'password')
+            ->addArgument(self::ARG_BASE_URL, InputArgument::OPTIONAL, 'Elasticms base url (default: EMS_BACKEND_URL)')
         ;
     }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Because the default is now EMS_BACKEND_URL environment variable, it should be at last position.

For better usage standalone, the username and password became options

```bash
php bin/console ems:admin:login http://myelasticms.test 
> Username 
> Password

php bin/console ems:admin:login http://myelasticms.test -u david
> Password

php bin/console ems:admin:login --username davmat
# will try to use EMS_BACKEND_URL 
> Password
```




