### PR TITLE
refactor(log): common log namespace

### DIFF
--- a/src/Common/Log/DoctrineHandler.php
+++ b/src/Common/Log/DoctrineHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Helper\Logger;
+namespace EMS\CommonBundle\Common\Log;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;

--- a/src/Common/Log/LocalizedLogger.php
+++ b/src/Common/Log/LocalizedLogger.php
@@ -4,21 +4,24 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Common\Log;
 
+use EMS\CommonBundle\Contracts\Log\LocalizedLoggerInterface;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LocalizedLogger extends AbstractLogger
+class LocalizedLogger extends AbstractLogger implements LocalizedLoggerInterface
 {
     private const PATTERN = '/%(?<parameter>(_|)[[:alnum:]_]*)%/m';
 
     private LoggerInterface $logger;
     private TranslatorInterface $translator;
+    private string $translationDomain;
 
-    public function __construct(LoggerInterface $logger, TranslatorInterface $translator)
+    public function __construct(LoggerInterface $logger, TranslatorInterface $translator, string $translationDomain)
     {
         $this->logger = $logger;
         $this->translator = $translator;
+        $this->translationDomain = $translationDomain;
     }
 
     public function log($level, $message, array $context = []): void
@@ -32,7 +35,7 @@ class LocalizedLogger extends AbstractLogger
     private function translateMessage(string $message, array &$context): string
     {
         $context['translation_message'] = $message;
-        $translation = $this->translator->trans($message, [], 'ems_logger');
+        $translation = $this->translator->trans($message, [], $this->translationDomain);
 
         return \preg_replace_callback(self::PATTERN, function ($match) use ($context) {
             return $context[$match['parameter']] ?? $match['parameter'];

--- a/src/Common/Log/LocalizedLogger.php
+++ b/src/Common/Log/LocalizedLogger.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Common\Log;
 
+use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LocalizedLogger implements LoggerInterface
+class LocalizedLogger extends AbstractLogger
 {
     private const PATTERN = '/%(?<parameter>(_|)[[:alnum:]_]*)%/m';
+
     private LoggerInterface $logger;
     private TranslatorInterface $translator;
 
@@ -17,46 +19,6 @@ class LocalizedLogger implements LoggerInterface
     {
         $this->logger = $logger;
         $this->translator = $translator;
-    }
-
-    public function emergency($message, array $context = []): void
-    {
-        $this->logger->emergency($this->translateMessage($message, $context), $context);
-    }
-
-    public function alert($message, array $context = []): void
-    {
-        $this->logger->alert($this->translateMessage($message, $context), $context);
-    }
-
-    public function critical($message, array $context = []): void
-    {
-        $this->logger->critical($this->translateMessage($message, $context), $context);
-    }
-
-    public function error($message, array $context = []): void
-    {
-        $this->logger->error($this->translateMessage($message, $context), $context);
-    }
-
-    public function warning($message, array $context = []): void
-    {
-        $this->logger->warning($this->translateMessage($message, $context), $context);
-    }
-
-    public function notice($message, array $context = []): void
-    {
-        $this->logger->notice($this->translateMessage($message, $context), $context);
-    }
-
-    public function info($message, array $context = []): void
-    {
-        $this->logger->info($this->translateMessage($message, $context), $context);
-    }
-
-    public function debug($message, array $context = []): void
-    {
-        $this->logger->debug($this->translateMessage($message, $context), $context);
     }
 
     public function log($level, $message, array $context = []): void

--- a/src/Common/Log/LocalizedLogger.php
+++ b/src/Common/Log/LocalizedLogger.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Helper\Log;
+namespace EMS\CommonBundle\Common\Log;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;

--- a/src/Common/Log/LocalizedLoggerFactory.php
+++ b/src/Common/Log/LocalizedLoggerFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\Common\Log;
+
+use EMS\CommonBundle\Contracts\Log\LocalizedLoggerFactoryInterface;
+use EMS\CommonBundle\Contracts\Log\LocalizedLoggerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class LocalizedLoggerFactory implements LocalizedLoggerFactoryInterface
+{
+    private TranslatorInterface $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function __invoke(LoggerInterface $logger, string $translationDomain): LocalizedLoggerInterface
+    {
+        return new LocalizedLogger($logger, $this->translator, $translationDomain);
+    }
+}

--- a/src/Contracts/Log/LocalizedLoggerFactoryInterface.php
+++ b/src/Contracts/Log/LocalizedLoggerFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\Contracts\Log;
+
+use Psr\Log\LoggerInterface;
+
+interface LocalizedLoggerFactoryInterface
+{
+    public function __invoke(LoggerInterface $logger, string $translationDomain): LocalizedLoggerInterface;
+}

--- a/src/Contracts/Log/LocalizedLoggerInterface.php
+++ b/src/Contracts/Log/LocalizedLoggerInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace EMS\CommonBundle\Contracts\Log;
+
+use Psr\Log\LoggerInterface;
+
+interface LocalizedLoggerInterface extends LoggerInterface
+{
+}

--- a/src/DependencyInjection/EMSCommonExtension.php
+++ b/src/DependencyInjection/EMSCommonExtension.php
@@ -22,6 +22,7 @@ class EMSCommonExtension extends Extension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('contracts.xml');
+        $loader->load('log.xml');
         $loader->load('services.xml');
         $loader->load('commands.xml');
         $loader->load('twig.xml');

--- a/src/Resources/config/contracts.xml
+++ b/src/Resources/config/contracts.xml
@@ -13,6 +13,8 @@
         <service id="EMS\CommonBundle\Contracts\File\FileReaderInterface" alias="ems_common.file.reader" />
         <service id="EMS\CommonBundle\Contracts\Generator\Pdf\PdfGeneratorInterface" alias="emsch.common.pdf_generator" />
 
+        <service id="EMS\CommonBundle\Contracts\Log\LocalizedLoggerFactoryInterface" alias="ems_common.common_log.localized_logger_factory" />
+
         <service id="EMS\CommonBundle\Contracts\ExpressionServiceInterface" alias="ems_common.service.expression_service" />
         <service id="EMS\CommonBundle\Contracts\SpreadsheetGeneratorServiceInterface" alias="ems_common.service.spreadsheet_generator_service" />
 

--- a/src/Resources/config/log.xml
+++ b/src/Resources/config/log.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <defaults public="false" autoconfigure="false" autowire="false" />
+
+        <service id="ems_common.repository.log" class="EMS\CommonBundle\Repository\LogRepository" public="true">
+            <argument type="service" id="doctrine"/>
+        </service>
+
+        <service id="ems.logger" alias="ems_common.localized_logger"/>
+        <service id="ems_common.localized_logger" class="EMS\CommonBundle\Common\Log\LocalizedLogger">
+            <argument type="service" id="logger" />
+            <argument type="service" id="translator" />
+        </service>
+
+        <service id="ems_common.monolog.doctrine" class="EMS\CommonBundle\Common\Log\DoctrineHandler">
+            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="security.token_storage" />
+            <argument type="string">%ems_common.log_level%</argument>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/log.xml
+++ b/src/Resources/config/log.xml
@@ -11,9 +11,7 @@
             <argument type="service" id="doctrine"/>
         </service>
 
-        <service id="ems.logger" alias="ems_common.localized_logger"/>
-        <service id="ems_common.localized_logger" class="EMS\CommonBundle\Common\Log\LocalizedLogger">
-            <argument type="service" id="logger" />
+        <service id="ems_common.common_log.localized_logger_factory" class="EMS\CommonBundle\Common\Log\LocalizedLoggerFactory">
             <argument type="service" id="translator" />
         </service>
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -62,19 +62,6 @@
             <argument type="service" id="logger" />
             <argument type="service" id="ems_common.elastica.client" />
         </service>
-        <service id="ems_common.monolog.doctrine" class="EMS\CommonBundle\Helper\Logger\DoctrineHandler">
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
-            <argument type="service" id="security.token_storage" />
-            <argument type="string">%ems_common.log_level%</argument>
-        </service>
-        <service id="ems_common.repository.log" class="EMS\CommonBundle\Repository\LogRepository" public="true">
-            <argument type="service" id="doctrine"/>
-        </service>
-        <service id="ems.logger" alias="ems_common.localized_logger"/>
-        <service id="ems_common.localized_logger" class="EMS\CommonBundle\Helper\Log\LocalizedLogger">
-            <argument type="service" id="logger" />
-            <argument type="service" id="translator" />
-        </service>
         <service id="ems.helper.admin_api" class="EMS\CommonBundle\Common\Admin\AdminHelper">
             <argument type="service" id="ems_common.core_api.factory" />
             <argument type="service" id="Psr\Cache\CacheItemPoolInterface" />


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Created a new namespace Common\Log which should contain all logging classes.

The service 'ems.logger' will be moved to the CoreBundle, for now it's only used there. But now we can define multiple loggers and define the translation domain + channel. Not all 'app'

Before
```xml
<service id="ems.logger" alias="ems_common.localized_logger"/>
<service id="ems_common.localized_logger" class="EMS\CommonBundle\Helper\Log\LocalizedLogger">
    <argument type="service" id="logger" />
    <argument type="service" id="translator" />
</service>
```

Now (in the core)
```xml
<service id="ems.logger" class="EMS\CommonBundle\Contracts\Log\LocalizedLoggerInterface">
    <factory service="EMS\CommonBundle\Contracts\Log\LocalizedLoggerFactoryInterface" />
    <argument type="service" id="logger" />
    <argument>app</argument>
    <tag name="monolog.logger" channel="core"/>
</service>
```

Offcourse we will change `app` to `core`. 

