### PR TITLE
feat: json menu nested diff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
 		"doctrine/doctrine-bundle": "^1.11|^2.5",
 		"doctrine/orm": "^2.6",
 		"dompdf/dompdf": "^v1.0.2",
+		"elasticms/helpers": "^1.0",
 		"guzzlehttp/guzzle": "^6.3",
 		"phpoffice/phpspreadsheet": "^1.16",
 		"promphp/prometheus_client_php": "^2.6",
@@ -57,21 +58,14 @@
 	},
 	"require-dev" : {
 		"friendsofphp/php-cs-fixer" : "^3.0",
-		"mockery/mockery" : "^0.9",
 		"phpstan/phpstan": "^0.12",
-		"phpunit/phpunit" : "^9.5",
-		"symfony/test-pack": "^1.0",
-		"symfony/web-profiler-bundle": "^4.4|^5.4",
-		"phpstan/phpstan-phpunit": "^0.12.8",
-		"phpstan/extension-installer": "^1.1"
+		"phpstan/extension-installer": "^1.1",
+		"symfony/test-pack": "^1.0"
 	},
 	"autoload" : {
 		"psr-4" : {
 			"EMS\\CommonBundle\\" : "src/"
-		},
-		"exclude-from-classmap" : [
-			"tests/"
-		]
+		}
 	},
 	"autoload-dev" : {
 		"psr-4" : {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,13 @@
         <env name="SYMFONY_PHPUNIT_VERSION" value="9.5"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
+
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="Unit suite">
             <directory>./tests/Unit</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,6 @@
         <ini name="error_reporting" value="-1"/>
         <ini name="intl.default_locale" value="en"/>
         <ini name="intl.error_level" value="0"/>
-        <ini name="memory_limit" value="256"/>
         <env name="SYMFONY_PHPUNIT_VERSION" value="9.5"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>

--- a/src/Json/JsonMenuNested.php
+++ b/src/Json/JsonMenuNested.php
@@ -4,25 +4,23 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Json;
 
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
  * @implements \IteratorAggregate<JsonMenuNested>
  */
-final class JsonMenuNested implements \IteratorAggregate
+final class JsonMenuNested implements \IteratorAggregate, \Countable
 {
-    /** @var string */
-    private $id;
-    /** @var string */
-    private $type;
-    /** @var string */
-    private $label;
+    private string $id;
+    private string $type;
+    private string $label;
     /** @var array<mixed> */
-    private $object;
+    private array $object;
     /** @var JsonMenuNested[] */
-    private $children = [];
-    /** @var JsonMenuNested|null */
-    private $parent;
+    private array $children = [];
+    /** @var ?JsonMenuNested */
+    private ?JsonMenuNested $parent = null;
     /** @var string[] */
     private array $descendantIds;
 
@@ -114,6 +112,36 @@ final class JsonMenuNested implements \IteratorAggregate
         }
     }
 
+    public function count(): int
+    {
+        return \count($this->children);
+    }
+
+    public function filterChildren(callable $callback): JsonMenuNested
+    {
+        $jsonMenuNested = new self(['id' => 'root', 'type' => 'root', 'label' => 'root']);
+        $jsonMenuNested->setChildren($this->recursiveFilterChildren($callback));
+
+        return $jsonMenuNested;
+    }
+
+    /**
+     * Return children that are not found in passed compareJsonMenuNested OR if found but the path is different (moved).
+     */
+    public function diffChildren(JsonMenuNested $compareJsonMenuNested): JsonMenuNested
+    {
+        return $this->filterChildren(function (JsonMenuNested $child) use ($compareJsonMenuNested) {
+            if (null === $compareChild = $compareJsonMenuNested->getItemById($child->getId())) {
+                return true;
+            }
+
+            $childPath = $child->getPath(fn (JsonMenuNested $p) => $p->getId());
+            $comparePath = $compareChild->getPath(fn (JsonMenuNested $p) => $p->getId());
+
+            return $childPath !== $comparePath;
+        });
+    }
+
     /**
      * @return iterable<JsonMenuNested>|JsonMenuNested[]
      */
@@ -136,6 +164,13 @@ final class JsonMenuNested implements \IteratorAggregate
                 yield $child;
             }
         }
+    }
+
+    public function changeId(): JsonMenuNested
+    {
+        $this->id = Uuid::uuid4()->toString();
+
+        return $this;
     }
 
     public function getItemById(string $id): ?JsonMenuNested
@@ -183,20 +218,20 @@ final class JsonMenuNested implements \IteratorAggregate
     /**
      * @return JsonMenuNested[]
      */
-    public function getChildren(): array
+    public function getChildren(?callable $map = null): array
     {
-        return $this->children;
+        return $map ? \array_map($map, $this->children) : $this->children;
     }
 
     /**
      * @return JsonMenuNested[]
      */
-    public function getPath(): array
+    public function getPath(?callable $map = null): array
     {
-        $path = [$this];
+        $path = [$map ? $map($this) : $this];
 
         if (null !== $this->parent && !$this->parent->isRoot()) {
-            $path = \array_merge($this->parent->getPath(), $path);
+            $path = \array_merge($this->parent->getPath($map), $path);
         }
 
         return $path;
@@ -207,9 +242,32 @@ final class JsonMenuNested implements \IteratorAggregate
         return $this->parent;
     }
 
+    public function addChild(JsonMenuNested $child): JsonMenuNested
+    {
+        $addChild = clone $child;
+        $addChild->setParent($this);
+
+        $this->children[] = $addChild;
+
+        return $this;
+    }
+
+    /**
+     * @param array{'id': string, 'label': ?string, 'type': string, 'children': array<mixed>} $child
+     */
+    public function addChildByArray(array $child): JsonMenuNested
+    {
+        return $this->addChild(new JsonMenuNested($child));
+    }
+
     public function hasChildren(): bool
     {
         return \count($this->children) > 0;
+    }
+
+    public function hasChild(JsonMenuNested $jsonMenuNested): bool
+    {
+        return 1 === \count($this->filterChildren(fn (JsonMenuNested $child) => $child->getId() === $jsonMenuNested->getId()));
     }
 
     public function isRoot(): bool
@@ -274,5 +332,24 @@ final class JsonMenuNested implements \IteratorAggregate
                 break;
             }
         }
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function recursiveFilterChildren(callable $callback): array
+    {
+        $result = [];
+
+        foreach ($this->children as $child) {
+            if ($callback($child)) {
+                $result[] = clone $child;
+            }
+            if ($child->hasChildren()) {
+                $result = [...$result, ...$child->recursiveFilterChildren($callback)];
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/Json/JsonMenuNested.php
+++ b/src/Json/JsonMenuNested.php
@@ -132,13 +132,21 @@ final class JsonMenuNested implements \IteratorAggregate, \Countable
     {
         return $this->filterChildren(function (JsonMenuNested $child) use ($compareJsonMenuNested) {
             if (null === $compareChild = $compareJsonMenuNested->getItemById($child->getId())) {
-                return true;
+                return true; // removed
+            }
+
+            if ($compareChild->getObject() !== $child->getObject()) {
+                return true; // updated
+            }
+
+            if (\count($compareChild->getChildren()) !== \count($child->getChildren())) {
+                return true; // new child
             }
 
             $childPath = $child->getPath(fn (JsonMenuNested $p) => $p->getId());
             $comparePath = $compareChild->getPath(fn (JsonMenuNested $p) => $p->getId());
 
-            return $childPath !== $comparePath;
+            return $childPath !== $comparePath; // moved
         });
     }
 

--- a/tests/Unit/Helper/ArrayToolTest.php
+++ b/tests/Unit/Helper/ArrayToolTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EMS\CommonBundle\Tests\Unit\Helper\Text;
+namespace EMS\CommonBundle\Tests\Unit\Helper;
 
 use EMS\CommonBundle\Helper\ArrayTool;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Helper/CacheTest.php
+++ b/tests/Unit/Helper/CacheTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EMS\CommonBundle\Tests\Unit\Helper\Text;
+namespace EMS\CommonBundle\Tests\Unit\Helper;
 
 use EMS\CommonBundle\Helper\Cache;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Json/JsonMenuNestedTest.php
+++ b/tests/Unit/Json/JsonMenuNestedTest.php
@@ -1,67 +1,42 @@
 <?php
 
-namespace EMS\CommonBundle\Tests\Unit\Helper\Text;
+namespace EMS\CommonBundle\Tests\Unit\Json;
 
 use EMS\CommonBundle\Json\JsonMenuNested;
 use PHPUnit\Framework\TestCase;
 
 class JsonMenuNestedTest extends TestCase
 {
-    /** @var JsonMenuNested */
-    private $jsonMenuNested;
+    private JsonMenuNested $jsonMenuNested;
 
     protected function setUp(): void
     {
-        $data = '{
-                    "id": "102a603e-b2ab-499d-b1d3-687a2e4ee168",
-                    "type": "theme",
-                    "object": 
-                    {
-                        "label_nl": "testExampleAdrienFR",
-                        "label_fr": "testExampleAdrienNL"
-                    },
-                    "label": "testadrienLabel",
-                    "children": 
-                    [
-                        {
-                            "id": "7b4f228f-3d04-4eb0-a826-aeaa1e8bc8aa",
-                            "object": {
-                            "label_nl": "testDocNL",
-                            "label_fr": "testDocFR"
-                            },
-                            "type": "theme_document",
-                            "label": "testDoc"
-                        }
-                    ]
-                }';
-        $data = \json_decode($data, true);
-        $this->jsonMenuNested = new JsonMenuNested($data);
+        $this->jsonMenuNested = JsonMenuNested::fromStructure(file_get_contents(__DIR__.'/json_menu_nested_1.json'));
     }
 
-    public function testGetter(): void
+    public function testMethods(): void
     {
-        self::assertSame('102a603e-b2ab-499d-b1d3-687a2e4ee168', $this->jsonMenuNested->getId());
-        self::assertSame('theme', $this->jsonMenuNested->getType());
-        self::assertSame('testadrienLabel', $this->jsonMenuNested->getLabel());
+        $this->assertSame('root', $this->jsonMenuNested->getId());
+        $this->assertSame('root', $this->jsonMenuNested->getLabel());
+
+        $player1Item = $this->jsonMenuNested->getItemById('0d19f63f-30c8-4bad-b0fd-ecc9d7b16c48');
+
+        $this->assertSame('player 1', $player1Item->getLabel());
+        $this->assertSame('player', $player1Item->getType());
     }
 
-    public function testGetIterator(): void
+    public function testLoopJsonMenuNested(): void
     {
+        $this->assertTrue($this->jsonMenuNested->hasChildren());
+        $this->assertTrue($this->jsonMenuNested->isRoot());
+
         $count = 0;
-        foreach ($this->jsonMenuNested->getIterator() as $json) {
-            self::assertInstanceOf(JsonMenuNested::class, $json);
+        foreach ($this->jsonMenuNested as $item) {
+            $this->assertInstanceOf(JsonMenuNested::class, $item);
             ++$count;
         }
-        $this->assertEquals(1, $count);
+        $this->assertEquals(6, $count);
     }
 
-    public function testHasChildren(): void
-    {
-        self::assertTrue($this->jsonMenuNested->hasChildren(), 'Has Children true');
-    }
 
-    public function testIsRoot(): void
-    {
-        self::assertTrue($this->jsonMenuNested->isRoot(), 'is Root true');
-    }
 }

--- a/tests/Unit/Json/JsonMenuNestedTest.php
+++ b/tests/Unit/Json/JsonMenuNestedTest.php
@@ -7,36 +7,114 @@ use PHPUnit\Framework\TestCase;
 
 class JsonMenuNestedTest extends TestCase
 {
-    private JsonMenuNested $jsonMenuNested;
+    private JsonMenuNested $jsonMenuNested1;
+    private JsonMenuNested $jsonMenuNested2;
 
     protected function setUp(): void
     {
-        $this->jsonMenuNested = JsonMenuNested::fromStructure(file_get_contents(__DIR__.'/json_menu_nested_1.json'));
+        $this->jsonMenuNested1 = JsonMenuNested::fromStructure(\file_get_contents(__DIR__.'/json_menu_nested_1.json'));
+        $this->jsonMenuNested2 = JsonMenuNested::fromStructure(\file_get_contents(__DIR__.'/json_menu_nested_2.json'));
     }
 
     public function testMethods(): void
     {
-        $this->assertSame('root', $this->jsonMenuNested->getId());
-        $this->assertSame('root', $this->jsonMenuNested->getLabel());
+        $this->assertSame('root', $this->jsonMenuNested1->getId());
+        $this->assertSame('root', $this->jsonMenuNested1->getLabel());
 
-        $player1Item = $this->jsonMenuNested->getItemById('0d19f63f-30c8-4bad-b0fd-ecc9d7b16c48');
+        $player1Item = $this->jsonMenuNested1->getItemById('c7b74edf-5cd1-4af8-a5f0-2ae8fdcc1540');
 
-        $this->assertSame('player 1', $player1Item->getLabel());
+        $this->assertSame('test player 1', $player1Item->getLabel());
         $this->assertSame('player', $player1Item->getType());
     }
 
     public function testLoopJsonMenuNested(): void
     {
-        $this->assertTrue($this->jsonMenuNested->hasChildren());
-        $this->assertTrue($this->jsonMenuNested->isRoot());
+        $this->assertTrue($this->jsonMenuNested1->hasChildren());
+        $this->assertTrue($this->jsonMenuNested1->isRoot());
 
         $count = 0;
-        foreach ($this->jsonMenuNested as $item) {
+        foreach ($this->jsonMenuNested1 as $item) {
             $this->assertInstanceOf(JsonMenuNested::class, $item);
             ++$count;
         }
         $this->assertEquals(6, $count);
     }
 
+    public function testHasChild()
+    {
+        $children = $this->jsonMenuNested1->getChildren();
 
+        foreach ($children as $child) {
+            $this->assertTrue($this->jsonMenuNested1->hasChild($child));
+        }
+    }
+
+    public function testChangeId()
+    {
+        $this->assertEquals('root', $this->jsonMenuNested1->getId());
+        $this->jsonMenuNested1->changeId();
+        $this->assertNotEquals('root', $this->jsonMenuNested1->getId());
+    }
+
+    public function testPathMap()
+    {
+        $callback = fn (JsonMenuNested $p) => $p->getLabel();
+        $player1 = $this->jsonMenuNested1->getItemById('c7b74edf-5cd1-4af8-a5f0-2ae8fdcc1540');
+
+        $this->assertSame(['root'], $this->jsonMenuNested1->getPath($callback));
+        $this->assertSame(['League 1', 'club 1', 'test player 1'], $player1->getPath($callback));
+    }
+
+    public function testDiff(): void
+    {
+        $movedPlayer = new JsonMenuNested(['id' => '6fccb8ac-1ce6-41ee-b7e5-c83ccdb6c674', 'label' => 'player moved', 'type' => 'player']);
+
+        $club1 = $this->jsonMenuNested1->getItemById('77d39331-88ff-4335-b249-9abb09264af7');
+        $club2 = $this->jsonMenuNested2->getItemById('032f6b45-8f4e-4fe2-8d42-2df4afa08c7c');
+
+        $club1->addChild($movedPlayer);
+        $club2->addChild($movedPlayer);
+
+        $callback = fn (JsonMenuNested $item) => 'player' === $item->getType();
+        $players1 = $this->jsonMenuNested1->filterChildren($callback);
+        $players2 = $this->jsonMenuNested2->filterChildren($callback);
+
+        $printLabel = fn (JsonMenuNested $item) => $item->getLabel();
+
+        $diff1Children = $players1->diffChildren($players2)->getChildren($printLabel);
+        $diff2Children = $players2->diffChildren($players1)->getChildren($printLabel);
+
+        self::assertSame(['player moved', 'test player 2'], $diff1Children, 'Removal and movement');
+        self::assertSame(['test player 3', 'player moved'], $diff2Children, 'Added and movement');
+    }
+
+    public function testDiffItem2RemovedFromMenuB()
+    {
+        $menuA = new JsonMenuNested(['id' => 'menuA', 'label' => 'menuA', 'type' => 'menu']);
+        $menuB = new JsonMenuNested(['id' => 'menuB', 'label' => 'menuB', 'type' => 'menu']);
+
+        $item1 = new JsonMenuNested(['id' => 'item1', 'label' => 'item 1', 'type' => 'item']);
+        $item2 = new JsonMenuNested(['id' => 'item2', 'label' => 'item 2', 'type' => 'item']);
+
+        $menuA->addChild($item1)->addChild($item2);
+        $menuB->addChild($item1);
+
+        $this->assertSame(['item 2'], $menuA->diffChildren($menuB)->getChildren(fn (JsonMenuNested $c) => $c->getLabel()));
+        $this->assertSame([], $menuB->diffChildren($menuA)->getChildren(fn (JsonMenuNested $c) => $c->getLabel()));
+    }
+
+    public function testDiffItem2RemovedFromMenuA()
+    {
+        $menuA = new JsonMenuNested(['id' => 'menuA', 'label' => 'menuA', 'type' => 'menu']);
+        $menuB = new JsonMenuNested(['id' => 'menuB', 'label' => 'menuB', 'type' => 'menu']);
+
+        $item1 = new JsonMenuNested(['id' => 'item1', 'label' => 'item 1', 'type' => 'item']);
+        $item2 = new JsonMenuNested(['id' => 'item2', 'label' => 'item 2', 'type' => 'item']);
+
+        $menuA->addChild($item1);
+        $menuB->addChild($item1)->addChild($item2);
+
+        $this->assertSame([], $menuA->diffChildren($menuB)->getChildren(fn (JsonMenuNested $c) => $c->getLabel()));
+        $this->assertSame(['item 2'], $menuB->diffChildren($menuA)->getChildren(fn (JsonMenuNested $c) => $c->getLabel()));
+    }
 }

--- a/tests/Unit/Json/json_menu_nested_1.json
+++ b/tests/Unit/Json/json_menu_nested_1.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "3d97346d-6c6e-44a8-8ead-5cb54fc3cb1f",
+    "label": "League 1",
+    "type": "league",
+    "object": {
+      "label": "League 1"
+    },
+    "children": [
+      {
+        "id": "77d39331-88ff-4335-b249-9abb09264af7",
+        "label": "club 1",
+        "type": "club",
+        "object": {
+          "label": "club 1"
+        },
+        "children": [
+          {
+            "id": "c7b74edf-5cd1-4af8-a5f0-2ae8fdcc1540",
+            "label": "player 1",
+            "type": "player",
+            "object": {
+              "label": "player 1",
+              "structure_player": "structure_player:e6c8a71f-3464-4b72-b97b-bcb6eb40d654"
+            },
+            "children": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "8a68224b-9e8c-427d-84a7-516395953800",
+    "label": "League 2",
+    "type": "league",
+    "object": {
+      "label": "League 2"
+    },
+    "children": [
+      {
+        "id": "032f6b45-8f4e-4fe2-8d42-2df4afa08c7c",
+        "label": "club 2",
+        "type": "club",
+        "object": {
+          "label": "club 2"
+        },
+        "children": [
+          {
+            "id": "0d19f63f-30c8-4bad-b0fd-ecc9d7b16c48",
+            "label": "player 1",
+            "type": "player",
+            "object": {
+              "label": "player 1",
+              "structure_player": "structure_player:357707c3-97a7-4eb2-88ba-56c3f3c07ce5"
+            },
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/Unit/Json/json_menu_nested_1.json
+++ b/tests/Unit/Json/json_menu_nested_1.json
@@ -17,10 +17,10 @@
         "children": [
           {
             "id": "c7b74edf-5cd1-4af8-a5f0-2ae8fdcc1540",
-            "label": "player 1",
+            "label": "test player 1",
             "type": "player",
             "object": {
-              "label": "player 1",
+              "label": "test player 1",
               "structure_player": "structure_player:e6c8a71f-3464-4b72-b97b-bcb6eb40d654"
             },
             "children": []
@@ -47,10 +47,10 @@
         "children": [
           {
             "id": "0d19f63f-30c8-4bad-b0fd-ecc9d7b16c48",
-            "label": "player 1",
+            "label": "test player 2",
             "type": "player",
             "object": {
-              "label": "player 1",
+              "label": "test player 2",
               "structure_player": "structure_player:357707c3-97a7-4eb2-88ba-56c3f3c07ce5"
             },
             "children": []

--- a/tests/Unit/Json/json_menu_nested_2.json
+++ b/tests/Unit/Json/json_menu_nested_2.json
@@ -14,7 +14,18 @@
         "object": {
           "label": "club 1"
         },
-        "children": []
+        "children": [
+          {
+            "id": "c7b74edf-5cd1-4af8-a5f0-2ae8fdcc1540",
+            "label": "test player 1",
+            "type": "player",
+            "object": {
+              "label": "test player 1",
+              "structure_player": "structure_player:e6c8a71f-3464-4b72-b97b-bcb6eb40d654"
+            },
+            "children": []
+          }
+        ]
       }
     ]
   },
@@ -35,21 +46,11 @@
         },
         "children": [
           {
-            "id": "0d19f63f-30c8-4bad-b0fd-ecc9d7b16c48",
-            "label": "player 1",
-            "type": "player",
-            "object": {
-              "label": "player 1",
-              "structure_player": "structure_player:357707c3-97a7-4eb2-88ba-56c3f3c07ce5"
-            },
-            "children": []
-          },
-          {
             "id": "85b756a7-6ac3-4be6-bcbb-dd66753b792f",
-            "label": "player 2",
+            "label": "test player 3",
             "type": "player",
             "object": {
-              "label": "player 2",
+              "label": "test player 3",
               "structure_player": "structure_player:e6c8a71f-3464-4b72-b97b-bcb6eb40d654"
             },
             "children": []

--- a/tests/Unit/Json/json_menu_nested_2.json
+++ b/tests/Unit/Json/json_menu_nested_2.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "3d97346d-6c6e-44a8-8ead-5cb54fc3cb1f",
+    "label": "League 1",
+    "type": "league",
+    "object": {
+      "label": "League 1"
+    },
+    "children": [
+      {
+        "id": "77d39331-88ff-4335-b249-9abb09264af7",
+        "label": "club 1",
+        "type": "club",
+        "object": {
+          "label": "club 1"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "8a68224b-9e8c-427d-84a7-516395953800",
+    "label": "League 2",
+    "type": "league",
+    "object": {
+      "label": "League 2"
+    },
+    "children": [
+      {
+        "id": "032f6b45-8f4e-4fe2-8d42-2df4afa08c7c",
+        "label": "club 2",
+        "type": "club",
+        "object": {
+          "label": "club 2"
+        },
+        "children": [
+          {
+            "id": "0d19f63f-30c8-4bad-b0fd-ecc9d7b16c48",
+            "label": "player 1",
+            "type": "player",
+            "object": {
+              "label": "player 1",
+              "structure_player": "structure_player:357707c3-97a7-4eb2-88ba-56c3f3c07ce5"
+            },
+            "children": []
+          },
+          {
+            "id": "85b756a7-6ac3-4be6-bcbb-dd66753b792f",
+            "label": "player 2",
+            "type": "player",
+            "object": {
+              "label": "player 2",
+              "structure_player": "structure_player:e6c8a71f-3464-4b72-b97b-bcb6eb40d654"
+            },
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Improved the json menu nested object, for better php functions.
The core needs to compare to jsonMenuNested objects

- Implemented Countable interface
- New function `filterChildren(callable $callback): JsonMenuNested`. This can not be used from twig!
- New function `diffChildren(JsonMenuNested $compareJsonMenuNested): JsonMenuNested`
- Add new function changeId, allows to fix duplicated ids inside a structure. 
- GetChildren and getPath now allow an optional callback argument. Easy printing in php.
- New function `addChild` & `addChildByArray`
- New function `hasChild`
