### PR TITLE
fix: emsHtml printUrls whitespaces

### DIFF
--- a/src/Common/Text/EmsHtml.php
+++ b/src/Common/Text/EmsHtml.php
@@ -35,7 +35,7 @@ final class EmsHtml extends Markup
 
     public function printUrls(string $format = ':content (:href)'): self
     {
-        $pattern = '/<a.*?href=[\n\s\r]*?"(?<href>.*?)"(.|\s)*?>(?<content>(.|\s)*?)<\/a>/';
+        $pattern = '/<a(.|\s)*?href=\s*?"(?<href>(.|\s)*?)"(.|\s)*?>(?<content>(.|\s)*?)<\/a>/';
 
         $replaced = \preg_replace_callback($pattern, function ($match) use ($format) {
             return \str_replace([':content', ':href'], [$match['content'], $match['href']], $format);

--- a/src/Common/Text/EmsHtml.php
+++ b/src/Common/Text/EmsHtml.php
@@ -35,7 +35,7 @@ final class EmsHtml extends Markup
 
     public function printUrls(string $format = ':content (:href)'): self
     {
-        $pattern = '/<a.*?href="(?<href>.*?)".*?>(?<content>.*?)<\/a>/';
+        $pattern = '/<a.*?href=[\n\s\r]*?"(?<href>.*?)"(.|\s)*?>(?<content>(.|\s)*?)<\/a>/';
 
         $replaced = \preg_replace_callback($pattern, function ($match) use ($format) {
             return \str_replace([':content', ':href'], [$match['content'], $match['href']], $format);


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Improve regex, for allowing newlines or spaces in/before href or other attributes or the text content

```
<a href="
 http://www.example.dev">
test
</a>
````