### PR TITLE
fix: json menu nested root underscore

### DIFF
--- a/src/Json/JsonMenuNested.php
+++ b/src/Json/JsonMenuNested.php
@@ -49,9 +49,9 @@ final class JsonMenuNested implements \IteratorAggregate, \Countable
     public static function fromStructure(string $structure): JsonMenuNested
     {
         return new self([
-           'id' => 'root',
-           'type' => 'root',
-           'label' => 'root',
+           'id' => '_root',
+           'type' => '_root',
+           'label' => '_root',
            'children' => \json_decode($structure, true),
         ]);
     }
@@ -119,7 +119,7 @@ final class JsonMenuNested implements \IteratorAggregate, \Countable
 
     public function filterChildren(callable $callback): JsonMenuNested
     {
-        $jsonMenuNested = new self(['id' => 'root', 'type' => 'root', 'label' => 'root']);
+        $jsonMenuNested = new self(['id' => '_root', 'type' => '_root', 'label' => '_root']);
         $jsonMenuNested->setChildren($this->recursiveFilterChildren($callback));
 
         return $jsonMenuNested;

--- a/tests/Unit/Json/JsonMenuNestedTest.php
+++ b/tests/Unit/Json/JsonMenuNestedTest.php
@@ -18,8 +18,8 @@ class JsonMenuNestedTest extends TestCase
 
     public function testMethods(): void
     {
-        $this->assertSame('root', $this->jsonMenuNested1->getId());
-        $this->assertSame('root', $this->jsonMenuNested1->getLabel());
+        $this->assertSame('_root', $this->jsonMenuNested1->getId());
+        $this->assertSame('_root', $this->jsonMenuNested1->getLabel());
 
         $player1Item = $this->jsonMenuNested1->getItemById('c7b74edf-5cd1-4af8-a5f0-2ae8fdcc1540');
 
@@ -51,9 +51,9 @@ class JsonMenuNestedTest extends TestCase
 
     public function testChangeId()
     {
-        $this->assertEquals('root', $this->jsonMenuNested1->getId());
+        $this->assertEquals('_root', $this->jsonMenuNested1->getId());
         $this->jsonMenuNested1->changeId();
-        $this->assertNotEquals('root', $this->jsonMenuNested1->getId());
+        $this->assertNotEquals('_root', $this->jsonMenuNested1->getId());
     }
 
     public function testPathMap()
@@ -61,7 +61,7 @@ class JsonMenuNestedTest extends TestCase
         $callback = fn (JsonMenuNested $p) => $p->getLabel();
         $player1 = $this->jsonMenuNested1->getItemById('c7b74edf-5cd1-4af8-a5f0-2ae8fdcc1540');
 
-        $this->assertSame(['root'], $this->jsonMenuNested1->getPath($callback));
+        $this->assertSame(['_root'], $this->jsonMenuNested1->getPath($callback));
         $this->assertSame(['League 1', 'club 1', 'test player 1'], $player1->getPath($callback));
     }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |y|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Json menu neseted -> 'root' to '_root'