### PR TITLE
fix(doctrine): log_message ouuid is not unique

### DIFF
--- a/src/Entity/Log.php
+++ b/src/Entity/Log.php
@@ -46,7 +46,7 @@ class Log implements EntityInterface
     private array $context = [];
 
     /**
-     * @ORM\Column(type="string", unique=true, nullable=true)
+     * @ORM\Column(type="string", nullable=true)
      */
     private ?string $ouuid = null;
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

We can have multiple records for the same revision ouuid. The unique flag was wrong.