### PR TITLE
fix: dont throw excection if the temp upload file is missing

### DIFF
--- a/src/Entity/Log.php
+++ b/src/Entity/Log.php
@@ -40,6 +40,7 @@ class Log implements EntityInterface
 
     /**
      * @var array<mixed>
+     *
      * @ORM\Column(type="json")
      */
     private array $context = [];
@@ -66,6 +67,7 @@ class Log implements EntityInterface
 
     /**
      * @var array<mixed>
+     *
      * @ORM\Column(type="json")
      */
     private array $extra = [];

--- a/src/Storage/Service/AbstractUrlStorage.php
+++ b/src/Storage/Service/AbstractUrlStorage.php
@@ -138,7 +138,11 @@ abstract class AbstractUrlStorage implements StorageInterface
     {
         $path = $this->getUploadPath($hash);
         if (!\file_exists($path)) {
-            throw new NotFoundHttpException('temporary file not found');
+            $this->logger->warning('Upload temporary file {path} not found', [
+                'path' => $path,
+            ]);
+
+            return false;
         }
 
         $file = \fopen($path, 'a');


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

dont throw excection if the temp upload file is missing, just return false